### PR TITLE
feat: add x key to kill pane with confirmation

### DIFF
--- a/src/muxpilot/app.py
+++ b/src/muxpilot/app.py
@@ -93,6 +93,7 @@ class MuxpilotApp(App[str | None]):
         Binding("w", "filter_waiting", "Waiting only"),
         Binding("c", "filter_all", "Show all"),
         Binding("n", "rename", "Rename"),
+        Binding("x", "kill_pane", "Kill pane"),
     ]
 
     def __init__(self) -> None:
@@ -106,6 +107,7 @@ class MuxpilotApp(App[str | None]):
         self._notify_channel = NotifyChannel()
         self._label_store = LabelStore()
         self._rename_key: str | None = None
+        self._kill_pane_id: str | None = None
         self.theme = self._label_store.get_theme()
 
     def watch_theme(self, theme: str) -> None:
@@ -364,8 +366,64 @@ class MuxpilotApp(App[str | None]):
         rename_input.remove_class("-active")
         self.query_one("#tmux-tree").focus()
 
+    def action_kill_pane(self) -> None:
+        """Start kill confirmation for the currently selected pane (x key)."""
+        tw = self.query_one("#tmux-tree", TmuxTreeView)
+        node = tw.cursor_node
+        if node is None or node == tw.root:
+            return
+
+        data = tw._node_data.get(node.id)
+        if not data:
+            return
+
+        node_type, session, window, pane = data
+        if node_type != "pane" or pane is None:
+            return
+
+        # Don't kill our own pane
+        if pane.pane_id == self._current_pane_id:
+            self._notify_channel.send("Cannot kill the current pane")
+            return
+
+        self._kill_pane_id = pane.pane_id
+        self._notify_channel.send(f"Kill pane {pane.pane_id}? (y/n)")
+
+    def _confirm_kill_pane(self) -> None:
+        """Execute the pending pane kill."""
+        if self._kill_pane_id is None:
+            return
+        pane_id = self._kill_pane_id
+        self._kill_pane_id = None
+
+        success = self._client.kill_pane(pane_id)
+        if success:
+            self._notify_channel.send(f"Killed pane {pane_id}")
+            asyncio.ensure_future(self._do_refresh())
+        else:
+            self._notify_channel.send(f"Failed to kill pane {pane_id}")
+
+    def _cancel_kill_pane(self) -> None:
+        """Cancel kill pane confirmation."""
+        if self._kill_pane_id is not None:
+            self._kill_pane_id = None
+            self._notify_channel.send("Kill cancelled")
+
     def on_key(self, event) -> None:
-        """Handle Escape key during rename."""
+        """Handle Escape key during rename or kill confirmation."""
+        # Kill confirmation mode
+        if self._kill_pane_id is not None:
+            if event.key in ("y", "enter"):
+                self._confirm_kill_pane()
+                event.prevent_default()
+                event.stop()
+            elif event.key in ("n", "escape"):
+                self._cancel_kill_pane()
+                event.prevent_default()
+                event.stop()
+            return
+
+        # Rename input escape
         rename_input = self.query_one("#rename-input", Input)
         if event.key == "escape" and rename_input.has_class("-active"):
             self._cancel_rename()

--- a/src/muxpilot/tmux_client.py
+++ b/src/muxpilot/tmux_client.py
@@ -106,6 +106,17 @@ class TmuxClient:
         target_pane.select()
         return True
 
+    def kill_pane(self, pane_id: str) -> bool:
+        """Kill the specified pane."""
+        pane = self._find_pane(pane_id)
+        if pane is None:
+            return False
+        try:
+            pane.kill()
+            return True
+        except libtmux.exc.LibTmuxException:
+            return False
+
     def capture_pane_content(self, pane_id: str, lines: int = 50) -> list[str]:
         """Capture the last N lines of output from a pane."""
         pane = self._find_pane(pane_id)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,6 +109,7 @@ def make_mock_client(
     mock.get_current_pane_id.return_value = current_pane_id
     mock.capture_pane_content.return_value = capture_content or ["user@host:~$ "]
     mock.navigate_to.return_value = True
+    mock.kill_pane.return_value = True
     mock.is_inside_tmux.return_value = current_pane_id is not None
     return mock
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -411,6 +411,159 @@ async def test_structural_events_still_notified():
 
 
 # ============================================================================
+# Kill pane (x key)
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_kill_pane_key_starts_confirm():
+    """Pressing x on a pane node should start kill confirmation."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0", is_active=False)])])
+    ])
+    app = _patched_app(tree=tree, current_pane_id="%99")
+    async with app.run_test() as pilot:
+        tw = app.query_one("#tmux-tree", TmuxTreeView)
+        tw.focus()
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.pause()
+
+        app.action_kill_pane()
+        await pilot.pause()
+
+        assert app._kill_pane_id == "%0"
+        # Notification should ask for confirmation
+        messages = [call.args[0] for call in app._notify_channel.send.call_args_list if call.args]
+        assert any("Kill pane %0? (y/n)" in m for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_kill_pane_confirm_y_kills():
+    """Pressing y during kill confirmation should call kill_pane."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0", is_active=False)])])
+    ])
+    app = _patched_app(tree=tree, current_pane_id="%99")
+    async with app.run_test() as pilot:
+        tw = app.query_one("#tmux-tree", TmuxTreeView)
+        tw.focus()
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.pause()
+
+        app.action_kill_pane()
+        await pilot.pause()
+
+        app._notify_channel.send.reset_mock()
+        await pilot.press("y")
+        await pilot.pause()
+
+        app._client.kill_pane.assert_called_once_with("%0")
+        assert app._kill_pane_id is None
+
+
+@pytest.mark.asyncio
+async def test_kill_pane_confirm_enter_kills():
+    """Pressing Enter during kill confirmation should also call kill_pane."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0", is_active=False)])])
+    ])
+    app = _patched_app(tree=tree, current_pane_id="%99")
+    async with app.run_test() as pilot:
+        tw = app.query_one("#tmux-tree", TmuxTreeView)
+        tw.focus()
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.pause()
+
+        app.action_kill_pane()
+        await pilot.pause()
+
+        app._notify_channel.send.reset_mock()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        app._client.kill_pane.assert_called_once_with("%0")
+        assert app._kill_pane_id is None
+
+
+@pytest.mark.asyncio
+async def test_kill_pane_cancel_n():
+    """Pressing n during kill confirmation should cancel."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0", is_active=False)])])
+    ])
+    app = _patched_app(tree=tree, current_pane_id="%99")
+    async with app.run_test() as pilot:
+        tw = app.query_one("#tmux-tree", TmuxTreeView)
+        tw.focus()
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.pause()
+
+        app.action_kill_pane()
+        await pilot.pause()
+
+        await pilot.press("n")
+        await pilot.pause()
+
+        app._client.kill_pane.assert_not_called()
+        assert app._kill_pane_id is None
+
+
+@pytest.mark.asyncio
+async def test_kill_pane_cancel_escape():
+    """Pressing Escape during kill confirmation should cancel."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0", is_active=False)])])
+    ])
+    app = _patched_app(tree=tree, current_pane_id="%99")
+    async with app.run_test() as pilot:
+        tw = app.query_one("#tmux-tree", TmuxTreeView)
+        tw.focus()
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.pause()
+
+        app.action_kill_pane()
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        app._client.kill_pane.assert_not_called()
+        assert app._kill_pane_id is None
+
+
+@pytest.mark.asyncio
+async def test_kill_pane_self_not_allowed():
+    """Pressing x on the current (self) pane should not start confirmation."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%5")])])
+    ])
+    app = _patched_app(tree=tree, current_pane_id="%5")
+    async with app.run_test() as pilot:
+        tw = app.query_one("#tmux-tree", TmuxTreeView)
+        tw.focus()
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.pause()
+
+        app.action_kill_pane()
+        await pilot.pause()
+
+        app._client.kill_pane.assert_not_called()
+        assert app._kill_pane_id is None
+
+
+# ============================================================================
 # NotifyChannel lifecycle
 # ============================================================================
 


### PR DESCRIPTION
## Summary
- Add `x` key binding to kill the selected pane with confirmation
- `y` or Enter to confirm, `n` or Escape to cancel
- Prevent killing the current (muxpilot) pane for safety
- Auto-refresh tree view after successful kill
- Add `kill_pane()` to `TmuxClient` using libtmux

## Test Plan
- [x] All 136 tests pass (`pytest tests/`)
- [x] 6 new tests cover confirmation, kill, cancel, and self-pane protection