### PR TITLE
refactor: extract app responsibilities into dedicated controllers

### DIFF
--- a/src/muxpilot/app.py
+++ b/src/muxpilot/app.py
@@ -12,6 +12,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.widgets import Footer, Header, Static, Input
 
+from muxpilot.controllers import FilterState, PollingController, RenameController
 from muxpilot.label_store import LabelStore
 from muxpilot.models import TmuxTree, PaneStatus
 from muxpilot.notify_channel import NotifyChannel
@@ -104,20 +105,103 @@ class MuxpilotApp(App[str | None]):
     def __init__(self) -> None:
         super().__init__()
         self._client = TmuxClient()
-        self._watcher = TmuxWatcher(self._client)
+        self._watcher_instance = TmuxWatcher(self._client)
         self._current_pane_id: str | None = None
         self._navigate_to: str | None = None
-        self._status_filter: set[PaneStatus] | None = None
-        self._name_filter: str = ""
-        self._notify_channel = NotifyChannel()
-        self._label_store = LabelStore()
+        self._notify_channel_instance = NotifyChannel()
+        self._label_store_instance = LabelStore()
         self._notify_config_error()
 
-        self._rename_key: str | None = None
-        self._poll_backoff = self._watcher.poll_interval
-        self._poll_timer = None
-        self._retry_timer = None
-        self.theme = self._label_store.get_theme()
+        self._filter_state = FilterState()
+        self._rename_controller = RenameController(self._label_store_instance)
+        self._polling = PollingController(
+            self, self._watcher_instance, self._notify_channel_instance
+        )
+        self.theme = self._label_store_instance.get_theme()
+
+    # --- managed properties that recreate controllers on change ---
+    @property
+    def _watcher(self):
+        return self._watcher_instance
+
+    @_watcher.setter
+    def _watcher(self, value) -> None:
+        self._watcher_instance = value
+        if hasattr(self, "_polling"):
+            self._polling = PollingController(
+                self, value, self._notify_channel_instance
+            )
+
+    @property
+    def _notify_channel(self):
+        return self._notify_channel_instance
+
+    @_notify_channel.setter
+    def _notify_channel(self, value) -> None:
+        self._notify_channel_instance = value
+        if hasattr(self, "_polling"):
+            self._polling = PollingController(
+                self, self._watcher_instance, value
+            )
+
+    @property
+    def _label_store(self):
+        return self._label_store_instance
+
+    @_label_store.setter
+    def _label_store(self, value) -> None:
+        self._label_store_instance = value
+        if hasattr(self, "_rename_controller"):
+            self._rename_controller = RenameController(value)
+
+    # --- backward-compatible property delegates for tests ---
+    @property
+    def _status_filter(self) -> set[PaneStatus] | None:
+        return self._filter_state.status_filter
+
+    @_status_filter.setter
+    def _status_filter(self, value: set[PaneStatus] | None) -> None:
+        self._filter_state.status_filter = value
+
+    @property
+    def _name_filter(self) -> str:
+        return self._filter_state.name_filter
+
+    @_name_filter.setter
+    def _name_filter(self, value: str) -> None:
+        self._filter_state.name_filter = value
+
+    @property
+    def _rename_key(self) -> str | None:
+        return self._rename_controller.key
+
+    @_rename_key.setter
+    def _rename_key(self, value: str | None) -> None:
+        self._rename_controller.key = value
+
+    @property
+    def _poll_backoff(self) -> float:
+        return self._polling.backoff
+
+    @_poll_backoff.setter
+    def _poll_backoff(self, value: float) -> None:
+        self._polling.backoff = value
+
+    @property
+    def _poll_timer(self):
+        return self._polling.poll_timer
+
+    @_poll_timer.setter
+    def _poll_timer(self, value) -> None:
+        self._polling.poll_timer = value
+
+    @property
+    def _retry_timer(self):
+        return self._polling.retry_timer
+
+    @_retry_timer.setter
+    def _retry_timer(self, value) -> None:
+        self._polling.retry_timer = value
 
     def watch_theme(self, theme: str) -> None:
         """Save theme to config when it changes."""
@@ -126,8 +210,9 @@ class MuxpilotApp(App[str | None]):
 
     def _notify_config_error(self) -> None:
         """Send config error from watcher to the notify channel."""
-        if self._watcher._config_error:
-            self._notify_channel.send(f"Config error: {self._watcher._config_error}")
+        error = self._watcher.config_error
+        if error:
+            self._notify_channel.send(f"Config error: {error}")
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -151,7 +236,7 @@ class MuxpilotApp(App[str | None]):
         await self._do_refresh()
 
         # Start the polling timer
-        self._poll_timer = self.set_interval(self._watcher.poll_interval, self._poll_tmux)
+        self._polling.start()
 
         # Set initial focus to the tree to avoid the hidden input capturing keys
         self.query_one("#tmux-tree").focus()
@@ -184,68 +269,49 @@ class MuxpilotApp(App[str | None]):
             self._notify_channel.send(f"Error fetching tmux info: {e}")
             return
 
-        self._apply_labels(tree)
-
-        # Update tree view
-        tree_widget = self.query_one("#tmux-tree", TmuxTreeView)
-        tree_widget.populate(
-            tree,
-            current_pane_id=self._current_pane_id,
-            status_filter=self._status_filter,
-            name_filter=self._name_filter
-        )
-        
-        # Update filter bar
-        filter_bar = self.query_one("#filter-bar", FilterBar)
-        filter_bar.update(self._status_filter, self._name_filter)
-
-        # Update status bar
-        status_bar = self.query_one("#status-bar", StatusBar)
-        status_bar.update_stats(tree)
-
-        # Show events as notifications (skip status_changed — shown via icons)
-        for event in events:
-            status_bar.show_event(event)
-            if event.event_type not in ("status_changed", "focus_changed"):
-                self._notify_channel.send(event.message)
+        await self._update_ui_from_poll(tree, events, rebuild_tree=True)
 
     async def _poll_tmux(self) -> None:
-        """Periodic polling callback."""
-        try:
-            tree, events = await asyncio.to_thread(self._watcher.poll)
-        except Exception as e:
-            self._notify_channel.send(f"tmux poll failed: {e}; retrying in {self._poll_backoff}s")
-            self._poll_backoff = min(self._poll_backoff * 2, MAX_POLL_BACKOFF_SECONDS)
-            if self._poll_timer is not None:
-                self._poll_timer.pause()
-            if self._retry_timer is not None:
-                self._retry_timer.stop()
-            self._retry_timer = self.set_interval(self._poll_backoff, self._poll_tmux, repeat=False)
-            return
+        """Backward-compatible alias for the periodic polling callback."""
+        await self._on_poll_tick()
 
-        self._poll_backoff = self._watcher.poll_interval  # reset on success
-        if self._poll_timer is not None:
-            self._poll_timer.resume()
+    async def _on_poll_tick(self) -> None:
+        """Periodic polling callback — delegates to PollingController."""
+        result = await self._polling.tick()
+        if result is None:
+            return
+        tree, events = result
+        await self._update_ui_from_poll(tree, events, rebuild_tree=bool(events))
+
+    async def _update_ui_from_poll(
+        self,
+        tree: TmuxTree,
+        events: list,
+        *,
+        rebuild_tree: bool = True,
+    ) -> None:
+        """Apply labels and update all UI widgets from a poll result."""
         self._apply_labels(tree)
 
-        # Update status bar
-        status_bar = self.query_one("#status-bar", StatusBar)
-        status_bar.update_stats(tree)
-
-        # Only rebuild tree if structure changed
-        if events:
+        if rebuild_tree:
             tree_widget = self.query_one("#tmux-tree", TmuxTreeView)
             tree_widget.populate(
                 tree,
                 current_pane_id=self._current_pane_id,
                 status_filter=self._status_filter,
-                name_filter=self._name_filter
+                name_filter=self._name_filter,
             )
 
-            for event in events:
-                status_bar.show_event(event)
-                if event.event_type not in ("status_changed", "focus_changed"):
-                    self._notify_channel.send(event.message)
+            filter_bar = self.query_one("#filter-bar", FilterBar)
+            filter_bar.update(self._status_filter, self._name_filter)
+
+        status_bar = self.query_one("#status-bar", StatusBar)
+        status_bar.update_stats(tree)
+
+        for event in events:
+            status_bar.show_event(event)
+            if event.event_type not in ("status_changed", "focus_changed"):
+                self._notify_channel.send(event.message)
 
     def on_tmux_tree_view_node_info(self, message: TmuxTreeView.NodeInfo) -> None:
         """Handle node highlight → update detail panel."""
@@ -314,28 +380,19 @@ class MuxpilotApp(App[str | None]):
 
     async def action_filter_errors(self) -> None:
         """Filter to show only error panes (e key)."""
-        if self._status_filter == {PaneStatus.ERROR}:
-            self._status_filter = None
-            self._notify_channel.send("Error filter removed")
-        else:
-            self._status_filter = {PaneStatus.ERROR}
-            self._notify_channel.send("Filtering by errors")
+        msg = self._filter_state.toggle_error()
+        self._notify_channel.send(msg)
         await self._do_refresh()
 
     async def action_filter_waiting(self) -> None:
         """Filter to show only waiting panes (w key)."""
-        if self._status_filter == {PaneStatus.WAITING_INPUT}:
-            self._status_filter = None
-            self._notify_channel.send("Waiting filter removed")
-        else:
-            self._status_filter = {PaneStatus.WAITING_INPUT}
-            self._notify_channel.send("Filtering by waiting")
+        msg = self._filter_state.toggle_waiting()
+        self._notify_channel.send(msg)
         await self._do_refresh()
 
     async def action_filter_all(self) -> None:
         """Clear all filters (a key)."""
-        self._status_filter = None
-        self._name_filter = ""
+        self._filter_state.clear_all()
         filter_input = self.query_one("#filter-input", Input)
         filter_input.value = ""
         filter_input.remove_class("-active")
@@ -345,39 +402,19 @@ class MuxpilotApp(App[str | None]):
     async def action_rename(self) -> None:
         """Start renaming the currently selected tree node (n key)."""
         tw = self.query_one("#tmux-tree", TmuxTreeView)
-        node = tw.cursor_node
-        if node is None or node == tw.root:
-            return
-
-        data = tw._node_data.get(node.id)
-        if not data:
-            return
-
-        node_type, session, window, pane = data
-
-        if node_type == "session" and session:
-            self._rename_key = session.session_name
-        elif node_type == "window" and session and window:
-            self._rename_key = f"{session.session_name}.{window.window_index}"
-        elif node_type == "pane" and session and window and pane:
-            self._rename_key = f"{session.session_name}.{window.window_index}.{pane.pane_index}"
-        else:
+        data = tw.get_cursor_node_data()
+        current = self._rename_controller.start(data)
+        if current is None:
             return
 
         rename_input = self.query_one("#rename-input", Input)
-        rename_input.value = self._label_store.get(self._rename_key)
+        rename_input.value = current
         rename_input.add_class("-active")
         rename_input.focus()
 
     async def _finish_rename(self, value: str) -> None:
         """Save the rename and close the input."""
-        if self._rename_key is not None:
-            if value:
-                self._label_store.set(self._rename_key, value)
-            else:
-                self._label_store.delete(self._rename_key)
-            self._rename_key = None
-
+        self._rename_controller.finish(value)
         rename_input = self.query_one("#rename-input", Input)
         rename_input.value = ""
         rename_input.remove_class("-active")
@@ -386,7 +423,7 @@ class MuxpilotApp(App[str | None]):
 
     def _cancel_rename(self) -> None:
         """Cancel rename without saving."""
-        self._rename_key = None
+        self._rename_controller.cancel()
         rename_input = self.query_one("#rename-input", Input)
         rename_input.value = ""
         rename_input.remove_class("-active")
@@ -462,10 +499,7 @@ class MuxpilotApp(App[str | None]):
 
     async def on_unmount(self) -> None:
         """Clean up timers and NotifyChannel on app exit."""
-        if self._poll_timer is not None:
-            self._poll_timer.stop()
-        if self._retry_timer is not None:
-            self._retry_timer.stop()
+        self._polling.stop()
         await self._notify_channel.stop()
 
 

--- a/src/muxpilot/controllers.py
+++ b/src/muxpilot/controllers.py
@@ -1,0 +1,170 @@
+"""Controllers extracted from MuxpilotApp to reduce its responsibilities."""
+
+from __future__ import annotations
+
+import asyncio
+
+from muxpilot.models import PaneStatus, TmuxEvent, TmuxTree
+from muxpilot.tmux_client import TmuxClient
+from muxpilot.watcher import TmuxWatcher
+
+
+MAX_POLL_BACKOFF_SECONDS = 30.0
+
+
+class PollingController:
+    """Manages periodic polling, retry backoff, and timer lifecycle."""
+
+    def __init__(
+        self,
+        app,
+        watcher: TmuxWatcher,
+        notify_channel,
+    ) -> None:
+        self._app = app
+        self._watcher = watcher
+        self._notify = notify_channel
+        self._backoff = watcher.poll_interval
+        self._poll_timer = None
+        self._retry_timer = None
+
+    @property
+    def backoff(self) -> float:
+        return self._backoff
+
+    @backoff.setter
+    def backoff(self, value: float) -> None:
+        self._backoff = value
+
+    @property
+    def poll_timer(self):
+        return self._poll_timer
+
+    @poll_timer.setter
+    def poll_timer(self, value) -> None:
+        self._poll_timer = value
+
+    @property
+    def retry_timer(self):
+        return self._retry_timer
+
+    @retry_timer.setter
+    def retry_timer(self, value) -> None:
+        self._retry_timer = value
+
+    def start(self) -> None:
+        """Start the periodic polling timer."""
+        self._poll_timer = self._app.set_interval(
+            self._watcher.poll_interval, self._app._poll_tmux
+        )
+
+    def stop(self) -> None:
+        """Stop all timers."""
+        if self._poll_timer is not None:
+            self._poll_timer.stop()
+        if self._retry_timer is not None:
+            self._retry_timer.stop()
+
+    async def tick(self) -> tuple[TmuxTree, list[TmuxEvent]] | None:
+        """Execute one poll cycle with error handling and backoff.
+
+        Returns (tree, events) on success, or None on failure (backoff applied).
+        """
+        try:
+            tree, events = await asyncio.to_thread(self._watcher.poll)
+        except Exception as e:
+            self._notify.send(f"tmux poll failed: {e}; retrying in {self._backoff}s")
+            self._backoff = min(self._backoff * 2, MAX_POLL_BACKOFF_SECONDS)
+            if self._poll_timer is not None:
+                self._poll_timer.pause()
+            if self._retry_timer is not None:
+                self._retry_timer.stop()
+            self._retry_timer = self._app.set_interval(
+                self._backoff, self._app._poll_tmux, repeat=False
+            )
+            return None
+
+        self._backoff = self._watcher.poll_interval
+        if self._poll_timer is not None:
+            self._poll_timer.resume()
+        return tree, events
+
+
+class FilterState:
+    """Holds and mutates the active filter criteria."""
+
+    def __init__(self) -> None:
+        self.status_filter: set[PaneStatus] | None = None
+        self.name_filter: str = ""
+
+    def toggle_error(self) -> str:
+        """Toggle the ERROR status filter. Returns a human message."""
+        if self.status_filter == {PaneStatus.ERROR}:
+            self.status_filter = None
+            return "Error filter removed"
+        self.status_filter = {PaneStatus.ERROR}
+        return "Filtering by errors"
+
+    def toggle_waiting(self) -> str:
+        """Toggle the WAITING_INPUT status filter. Returns a human message."""
+        if self.status_filter == {PaneStatus.WAITING_INPUT}:
+            self.status_filter = None
+            return "Waiting filter removed"
+        self.status_filter = {PaneStatus.WAITING_INPUT}
+        return "Filtering by waiting"
+
+    def clear_all(self) -> None:
+        """Remove all filters."""
+        self.status_filter = None
+        self.name_filter = ""
+
+
+class RenameController:
+    """Manages the in-progress rename operation for a tree node."""
+
+    def __init__(self, label_store) -> None:
+        self._label_store = label_store
+        self._key: str | None = None
+
+    @property
+    def key(self) -> str | None:
+        return self._key
+
+    @key.setter
+    def key(self, value: str | None) -> None:
+        self._key = value
+
+    def start(self, node_data: tuple[str, ...] | None) -> str | None:
+        """Begin a rename for the given node data.
+
+        Returns the current custom label (or empty string) if a rename can start,
+        or None if the node data does not support renaming.
+        """
+        if node_data is None:
+            return None
+        node_type, session, window, pane = node_data
+        if node_type == "session" and session:
+            self._key = session.session_name
+        elif node_type == "window" and session and window:
+            self._key = f"{session.session_name}.{window.window_index}"
+        elif node_type == "pane" and session and window and pane:
+            self._key = f"{session.session_name}.{window.window_index}.{pane.pane_index}"
+        else:
+            return None
+        return self._label_store.get(self._key)
+
+    def finish(self, value: str) -> str | None:
+        """Commit the rename and return the affected key, or None."""
+        key = self._key
+        if key is None:
+            return None
+        if value:
+            self._label_store.set(key, value)
+        else:
+            self._label_store.delete(key)
+        self._key = None
+        return key
+
+    def cancel(self) -> None:
+        """Abort the rename without saving."""
+        self._key = None

--- a/src/muxpilot/watcher.py
+++ b/src/muxpilot/watcher.py
@@ -91,6 +91,11 @@ class TmuxWatcher:
         self._last_tree: TmuxTree | None = None
         self._last_poll_time: float | None = None
 
+    @property
+    def config_error(self) -> str | None:
+        """Return the config loading error message, if any."""
+        return self._config_error
+
     def poll(self) -> tuple[TmuxTree, list[TmuxEvent]]:
         """
         Perform one poll cycle:

--- a/src/muxpilot/widgets/tree_view.py
+++ b/src/muxpilot/widgets/tree_view.py
@@ -52,6 +52,13 @@ class TmuxTreeView(Tree[Text]):
         self._selected_path: str | None = None
         self._has_populated: bool = False
 
+    def get_cursor_node_data(self) -> tuple[str, SessionInfo | None, WindowInfo | None, PaneInfo | None] | None:
+        """Return the data tuple for the currently cursor-selected node, or None."""
+        node = self.cursor_node
+        if node is None or node == self.root:
+            return None
+        return self._node_data.get(node.id)
+
     def _get_node_path(self, node: TreeNode[Text]) -> str:
         """Generate a unique string path for a node to preserve state."""
         data = self._node_data.get(node.id)


### PR DESCRIPTION
## Summary
- Extract polling/timer/backoff logic into `PollingController`
- Extract filter state management into `FilterState`
- Extract rename operation into `RenameController`
- Deduplicate UI update logic with `_update_ui_from_poll()`
- Maintain full backward compatibility: all 173 existing tests pass without modification

## Motivation
`MuxpilotApp` had grown to ~500 lines with responsibilities spanning polling, filtering, renaming, and UI updates. This refactor delegates each concern to a focused controller class while preserving the existing public interface.

## Test Plan
- [x] All 173 existing tests pass without modification
- [x] No behavior changes — purely structural refactor