### PR TITLE
ux: simplify status icons and remove emoji from tree labels

### DIFF
--- a/src/muxpilot/models.py
+++ b/src/muxpilot/models.py
@@ -9,22 +9,16 @@ from enum import Enum
 class PaneStatus(Enum):
     """Estimated status of a pane based on its output patterns."""
 
-    ACTIVE = "active"          # 出力中（ログが流れている等）
-    IDLE = "idle"              # 出力停止中
+    ACTIVE = "active"          # 実行中（出力変化あり、または変化停止中）
     WAITING_INPUT = "waiting"  # プロンプト表示中（指示待ち）
     ERROR = "error"            # エラーパターン検出
-    COMPLETED = "completed"    # コマンド完了（シェルプロンプト復帰）
-    UNKNOWN = "unknown"        # 初回・判定不能
 
 
 # ステータスに対応するアイコン
 STATUS_ICONS: dict[PaneStatus, str] = {
     PaneStatus.ACTIVE: "●",
-    PaneStatus.IDLE: "○",
     PaneStatus.WAITING_INPUT: "◆",
     PaneStatus.ERROR: "▲",
-    PaneStatus.COMPLETED: "■",
-    PaneStatus.UNKNOWN: "?",
 }
 
 
@@ -39,7 +33,7 @@ class PaneInfo:
     is_active: bool
     width: int
     height: int
-    status: PaneStatus = PaneStatus.UNKNOWN
+    status: PaneStatus = PaneStatus.ACTIVE
     is_self: bool = False
     custom_label: str = ""
     full_command: str = ""
@@ -85,9 +79,9 @@ class WindowInfo:
     def display_label(self) -> str:
         """Label for tree view display."""
         if self.custom_label:
-            return f"🪟 {self.custom_label}"
+            return f"□ {self.custom_label}"
         active = " *" if self.is_active else ""
-        return f"🪟 {self.window_index}: {self.window_name}{active}"
+        return f"□ {self.window_index}: {self.window_name}{active}"
 
 
 @dataclass
@@ -104,9 +98,9 @@ class SessionInfo:
     def display_label(self) -> str:
         """Label for tree view display."""
         if self.custom_label:
-            return f"📦 {self.custom_label}"
+            return f"■ {self.custom_label}"
         attached = " (attached)" if self.is_attached else ""
-        return f"📦 {self.session_name}{attached}"
+        return f"■ {self.session_name}{attached}"
 
 
 @dataclass
@@ -141,7 +135,7 @@ class PaneActivity:
     last_content_hash: str = ""
     last_line: str = ""
     idle_seconds: float = 0.0
-    status: PaneStatus = PaneStatus.UNKNOWN
+    status: PaneStatus = PaneStatus.ACTIVE
 
 
 @dataclass

--- a/src/muxpilot/watcher.py
+++ b/src/muxpilot/watcher.py
@@ -202,20 +202,10 @@ class TmuxWatcher:
         # Check if the last line looks like a prompt (waiting for input)
         for pattern in self.prompt_patterns:
             if pattern.search(last_line):
-                if idle_seconds > self.idle_threshold:
-                    return PaneStatus.WAITING_INPUT
-                else:
-                    return PaneStatus.COMPLETED
+                return PaneStatus.WAITING_INPUT
 
-        # Check idle state
-        if idle_seconds > self.idle_threshold:
-            return PaneStatus.IDLE
-
-        # Content is changing = active
-        if idle_seconds == 0.0:
-            return PaneStatus.ACTIVE
-
-        return PaneStatus.IDLE
+        # Default to active
+        return PaneStatus.ACTIVE
 
     def _detect_structural_changes(
         self,

--- a/src/muxpilot/widgets/status_bar.py
+++ b/src/muxpilot/widgets/status_bar.py
@@ -23,11 +23,8 @@ class StatusBar(Static):
     # Icon legend labels
     _STATUS_LABELS: dict[PaneStatus, str] = {
         PaneStatus.ACTIVE: "active",
-        PaneStatus.IDLE: "idle",
         PaneStatus.WAITING_INPUT: "waiting",
         PaneStatus.ERROR: "error",
-        PaneStatus.COMPLETED: "done",
-        PaneStatus.UNKNOWN: "unknown",
     }
 
     def __init__(self, name: str | None = None, id: str | None = None) -> None:
@@ -50,8 +47,8 @@ class StatusBar(Static):
             status_counts[pane.status] = status_counts.get(pane.status, 0) + 1
 
         parts = [
-            f"📦 {tree.total_sessions}",
-            f"🪟 {tree.total_windows}",
+            f"■ {tree.total_sessions}",
+            f"□ {tree.total_windows}",
             f"▣ {tree.total_panes}",
         ]
 

--- a/src/muxpilot/widgets/tree_view.py
+++ b/src/muxpilot/widgets/tree_view.py
@@ -183,7 +183,7 @@ class TmuxTreeView(Tree[Text]):
                     for pane in panes:
                         label_text = Text.from_markup(pane.display_label)
                         if pane.is_active:
-                            label_text.stylize("bold reverse")
+                            label_text.stylize("bold")
 
                         pane_node = window_node.add_leaf(label_text)
                         self._node_data[pane_node.id] = ("pane", session, window, pane)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def make_pane(
     is_active: bool = True,
     width: int = 80,
     height: int = 24,
-    status: PaneStatus = PaneStatus.UNKNOWN,
+    status: PaneStatus = PaneStatus.ACTIVE,
     is_self: bool = False,
     custom_label: str = "",
     full_command: str = "",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -505,9 +505,9 @@ async def test_status_changed_events_not_notified():
         status_event = TmuxEvent(
             event_type="status_changed",
             pane_id="%0",
-            old_status=PaneStatus.IDLE,
+            old_status=PaneStatus.WAITING_INPUT,
             new_status=PaneStatus.ACTIVE,
-            message="%0: idle → active",
+            message="%0: waiting → active",
         )
         # Call the event handling code path directly
         status_bar = app.query_one("#status-bar")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,11 +29,8 @@ def test_status_icons_are_unified_geometric_symbols():
     """STATUS_ICONS should use consistent geometric symbols, not mixed emoji."""
     expected = {
         PaneStatus.ACTIVE: "●",
-        PaneStatus.IDLE: "○",
         PaneStatus.WAITING_INPUT: "◆",
         PaneStatus.ERROR: "▲",
-        PaneStatus.COMPLETED: "■",
-        PaneStatus.UNKNOWN: "?",
     }
     assert STATUS_ICONS == expected
 
@@ -100,7 +97,7 @@ class TestPaneInfoDisplayLabel:
         pane = make_pane(
             current_command="vim",
             current_path="/home/user/project",
-            status=PaneStatus.IDLE,
+            status=PaneStatus.ACTIVE,
             custom_label="",
         )
         assert "vim" in pane.display_label
@@ -164,7 +161,7 @@ class TestWindowInfoDisplayLabel:
     def test_display_label_with_custom_label(self) -> None:
         """When custom_label is set, display_label should return it."""
         window = make_window(window_name="editor", is_active=True, custom_label="My Editor")
-        assert window.display_label == "🪟 My Editor"
+        assert window.display_label == "□ My Editor"
 
     def test_display_label_custom_label_empty_uses_default(self) -> None:
         """When custom_label is empty, display_label should use default format."""
@@ -196,7 +193,7 @@ class TestSessionInfoDisplayLabel:
     def test_display_label_with_custom_label(self) -> None:
         """When custom_label is set, display_label should return it."""
         session = make_session(session_name="work", is_attached=True, custom_label="🚀 Main")
-        assert session.display_label == "📦 🚀 Main"
+        assert session.display_label == "■ 🚀 Main"
 
     def test_display_label_custom_label_empty_uses_default(self) -> None:
         """When custom_label is empty, display_label should use default format."""

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -32,10 +32,10 @@ class TestDetermineStatus:
         assert self._status(["output"], "output", idle=0.0) == PaneStatus.ACTIVE
 
     def test_idle_when_no_change(self):
-        assert self._status(["output"], "output", idle=15.0) == PaneStatus.IDLE
+        assert self._status(["output"], "output", idle=15.0) == PaneStatus.ACTIVE
 
     def test_completed_shell_prompt(self):
-        assert self._status(["user@host:~$ "], "user@host:~$ ", idle=0.0) == PaneStatus.COMPLETED
+        assert self._status(["user@host:~$ "], "user@host:~$ ", idle=0.0) == PaneStatus.WAITING_INPUT
 
     def test_waiting_shell_prompt(self):
         assert self._status(["user@host:~$ "], "user@host:~$ ", idle=15.0) == PaneStatus.WAITING_INPUT


### PR DESCRIPTION
## Summary
- Reduce PaneStatus from 6 values to 3: active, waiting, error (remove idle/completed/unknown)
- Replace emoji (📦🪟) with Unicode symbols (■□) for session/window labels to avoid font rendering issues
- Replace bold+reverse with bold only for active pane highlighting
- Simplify watcher status detection logic accordingly

## Test Plan
- [x] All tests pass (170 passed)
- [x] Status icons unified to geometric symbols
- [x] No emoji in tree labels