### PR TITLE
ux: dim inactive pane labels in tree view

### DIFF
--- a/src/muxpilot/widgets/tree_view.py
+++ b/src/muxpilot/widgets/tree_view.py
@@ -184,6 +184,8 @@ class TmuxTreeView(Tree[Text]):
                         label_text = Text.from_markup(pane.display_label)
                         if pane.is_active:
                             label_text.stylize("bold")
+                        else:
+                            label_text.stylize("dim")
 
                         pane_node = window_node.add_leaf(label_text)
                         self._node_data[pane_node.id] = ("pane", session, window, pane)

--- a/tests/test_tree_view.py
+++ b/tests/test_tree_view.py
@@ -4,6 +4,33 @@ from muxpilot.widgets.tree_view import TmuxTreeView
 from conftest import make_tree, make_session, make_window, make_pane
 
 
+def test_inactive_pane_is_dimmed():
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[
+            make_pane(pane_id="%0", is_active=False),
+        ])])
+    ])
+    tw = TmuxTreeView()
+    tw.populate(tree)
+    pane_node = tw.root.children[0].children[0].children[0]
+    label = pane_node.label
+    # rich.Text.spans contains style info
+    assert any("dim" in (span.style or "") for span in label.spans)
+
+
+def test_active_pane_is_not_dimmed():
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[
+            make_pane(pane_id="%0", is_active=True),
+        ])])
+    ])
+    tw = TmuxTreeView()
+    tw.populate(tree)
+    pane_node = tw.root.children[0].children[0].children[0]
+    label = pane_node.label
+    assert not any("dim" in (span.style or "") for span in label.spans)
+
+
 def test_self_pane_hidden():
     tree = make_tree(sessions=[
         make_session(windows=[make_window(panes=[


### PR DESCRIPTION
## Summary
Inactive pane labels in the tree view are now rendered with `dim` style, making them visually distinct from the active pane (which uses `bold`).

## Changes
- `src/muxpilot/widgets/tree_view.py`: apply `dim` style to inactive pane labels
- `tests/test_tree_view.py`: add tests verifying dim for inactive and no-dim for active

## Test Plan
- [x] All tests pass (172 passed)