### PR TITLE
Remove 'a' key collapse/expand toggle

### DIFF
--- a/src/muxpilot/screens/help_screen.py
+++ b/src/muxpilot/screens/help_screen.py
@@ -43,7 +43,6 @@ class HelpScreen(ModalScreen[None]):
                 ("↑ / k", "Move cursor up"),
                 ("↓ / j", "Move cursor down"),
                 ("Enter", "Jump to selected pane"),
-                ("a", "Collapse / expand all"),
                 ("r", "Manual refresh"),
                 ("/", "Toggle name filter"),
                 ("e", "Show only error panes"),

--- a/src/muxpilot/widgets/tree_view.py
+++ b/src/muxpilot/widgets/tree_view.py
@@ -18,7 +18,6 @@ class TmuxTreeView(Tree[Text]):
     BINDINGS = [
         ("k", "cursor_up", "Up"),
         ("j", "cursor_down", "Down"),
-        ("a", "toggle_expand", "Collapse/Expand"),
     ]
 
     @dataclass
@@ -196,26 +195,6 @@ class TmuxTreeView(Tree[Text]):
             self._restore_state()
 
         self._has_populated = True
-
-    def action_toggle_expand(self) -> None:
-        """Toggle collapse/expand on ALL expandable nodes in the tree."""
-        expandable = []
-        queue = [self.root]
-        while queue:
-            node = queue.pop(0)
-            if node != self.root and node.allow_expand:
-                expandable.append(node)
-            queue.extend(node.children)
-
-        if not expandable:
-            return
-
-        any_expanded = any(n.is_expanded for n in expandable)
-        for node in expandable:
-            if any_expanded:
-                node.collapse()
-            else:
-                node.expand()
 
     def on_tree_node_highlighted(self, event: Tree.NodeHighlighted[Text]) -> None:
         """When a node is highlighted, emit NodeInfo for the detail panel."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -417,64 +417,6 @@ async def test_status_bar_shows_icon_legend():
             assert icon in text, f"Icon {icon!r} for {status.value} not found in status bar"
 
 
-# ============================================================================
-# Keyboard: 'a' toggles collapse/expand on ALL tree nodes
-# ============================================================================
-
-
-@pytest.mark.asyncio
-async def test_a_key_collapses_all_nodes():
-    """Pressing 'a' when nodes are expanded should collapse all session/window nodes."""
-    tree = make_tree(sessions=[
-        make_session(session_id="$0", session_name="s0", windows=[
-            make_window(window_id="@0", panes=[make_pane(pane_id="%0")]),
-            make_window(window_id="@1", window_name="w1", panes=[make_pane(pane_id="%1")]),
-        ]),
-        make_session(session_id="$1", session_name="s1", windows=[
-            make_window(window_id="@2", window_name="w2", panes=[make_pane(pane_id="%2")]),
-        ]),
-    ])
-    app = _patched_app(tree=tree)
-    async with app.run_test() as pilot:
-        tw = app.query_one("#tmux-tree", TmuxTreeView)
-
-        # All nodes should be expanded initially
-        expandable = [n for n in _all_nodes(tw) if n.allow_expand and n != tw.root]
-        assert all(n.is_expanded for n in expandable), "All nodes should start expanded"
-
-        # Press 'a' → all should collapse
-        await pilot.press("a")
-        await pilot.pause()
-        expandable = [n for n in _all_nodes(tw) if n.allow_expand and n != tw.root]
-        assert all(not n.is_expanded for n in expandable), "All nodes should be collapsed after 'a'"
-
-
-@pytest.mark.asyncio
-async def test_a_key_expands_all_when_all_collapsed():
-    """Pressing 'a' when all nodes are collapsed should expand all."""
-    tree = make_tree(sessions=[
-        make_session(session_id="$0", session_name="s0", windows=[
-            make_window(window_id="@0", panes=[make_pane(pane_id="%0")]),
-        ]),
-        make_session(session_id="$1", session_name="s1", windows=[
-            make_window(window_id="@1", window_name="w1", panes=[make_pane(pane_id="%1")]),
-        ]),
-    ])
-    app = _patched_app(tree=tree)
-    async with app.run_test() as pilot:
-        tw = app.query_one("#tmux-tree", TmuxTreeView)
-
-        # Collapse all first
-        await pilot.press("a")
-        await pilot.pause()
-
-        # Press 'a' again → all should expand
-        await pilot.press("a")
-        await pilot.pause()
-        expandable = [n for n in _all_nodes(tw) if n.allow_expand and n != tw.root]
-        assert all(n.is_expanded for n in expandable), "All nodes should be expanded after second 'a'"
-
-
 def _all_nodes(tw: TmuxTreeView):
     """Collect all tree nodes via BFS."""
     nodes = []

--- a/tests/test_tree_view.py
+++ b/tests/test_tree_view.py
@@ -16,39 +16,3 @@ def test_self_pane_hidden():
     assert "%1" not in tw._pane_map
 
 
-def test_collapsed_state_preserved_after_repopulate():
-    """After collapsing all nodes with 'a', repopulate() must keep them collapsed."""
-    tree = make_tree(sessions=[
-        make_session(session_id="$0", session_name="s0", windows=[
-            make_window(window_id="@0", panes=[make_pane(pane_id="%0")]),
-            make_window(window_id="@1", window_name="w1", panes=[make_pane(pane_id="%1")]),
-        ]),
-    ])
-    tw = TmuxTreeView()
-    tw.populate(tree)
-
-    # Collapse all nodes via action_toggle_expand
-    tw.action_toggle_expand()
-
-    # Verify all expandable nodes are collapsed
-    expandable = []
-    queue = [tw.root]
-    while queue:
-        node = queue.pop(0)
-        if node != tw.root and node.allow_expand:
-            expandable.append(node)
-        queue.extend(node.children)
-    assert all(not n.is_expanded for n in expandable), "All nodes should be collapsed after toggle"
-
-    # Repopulate with the same tree
-    tw.populate(tree)
-
-    # Verify all expandable nodes are still collapsed
-    expandable = []
-    queue = [tw.root]
-    while queue:
-        node = queue.pop(0)
-        if node != tw.root and node.allow_expand:
-            expandable.append(node)
-        queue.extend(node.children)
-    assert all(not n.is_expanded for n in expandable), "All nodes should stay collapsed after repopulate"


### PR DESCRIPTION
## Summary
- Remove the `a` key binding for collapsing/expanding all tree nodes.
- Remove `action_toggle_expand()` from `TmuxTreeView`.
- Remove related tests (`test_a_key_collapses_all_nodes`, `test_a_key_expands_all_when_all_collapsed`, `test_collapsed_state_preserved_after_repopulate`).
- Remove the `a` key description from the help screen.

## Rationale
The collapse/expand feature is no longer needed for navigation.

## Verification
- All remaining tests pass (167 passed).