### PR TITLE
Make n-key rename an in-memory overlay without persisting to config

### DIFF
--- a/src/muxpilot/app.py
+++ b/src/muxpilot/app.py
@@ -113,7 +113,7 @@ class MuxpilotApp(App[str | None]):
         self._notify_config_error()
 
         self._filter_state = FilterState()
-        self._rename_controller = RenameController(self._label_store_instance)
+        self._rename_controller = RenameController()
         self._polling = PollingController(
             self, self._watcher_instance, self._notify_channel_instance
         )
@@ -151,8 +151,6 @@ class MuxpilotApp(App[str | None]):
     @_label_store.setter
     def _label_store(self, value) -> None:
         self._label_store_instance = value
-        if hasattr(self, "_rename_controller"):
-            self._rename_controller = RenameController(value)
 
     # --- backward-compatible property delegates for tests ---
     @property
@@ -245,7 +243,7 @@ class MuxpilotApp(App[str | None]):
         self.set_interval(NOTIFY_CHECK_INTERVAL, self._check_notifications)
 
     def _apply_labels(self, tree: TmuxTree) -> None:
-        """Apply custom labels from LabelStore to the tree snapshot."""
+        """Apply custom labels from LabelStore and in-memory overlays to the tree."""
         for session in tree.sessions:
             label = self._label_store.get(session.session_name)
             if label:
@@ -260,6 +258,8 @@ class MuxpilotApp(App[str | None]):
                     label = self._label_store.get(key)
                     if label:
                         pane.custom_label = label
+        # In-memory overlays take precedence and are never persisted.
+        self._rename_controller.apply(tree)
 
     async def _do_refresh(self) -> None:
         """Fetch tmux tree and update the UI."""

--- a/src/muxpilot/controllers.py
+++ b/src/muxpilot/controllers.py
@@ -120,10 +120,14 @@ class FilterState:
 
 
 class RenameController:
-    """Manages the in-progress rename operation for a tree node."""
+    """Manages the in-progress rename operation for a tree node.
 
-    def __init__(self, label_store) -> None:
-        self._label_store = label_store
+    Labels are kept only in memory (overlays).  They are never persisted to
+    disk — when the muxpilot process exits the overlays are lost.
+    """
+
+    def __init__(self) -> None:
+        self._overlays: dict[str, str] = {}
         self._key: str | None = None
 
     @property
@@ -134,11 +138,26 @@ class RenameController:
     def key(self, value: str | None) -> None:
         self._key = value
 
+    def get(self, key: str) -> str:
+        """Return the in-memory overlay label for *key*, or empty string."""
+        return self._overlays.get(key, "")
+
+    def set(self, key: str, value: str) -> None:
+        """Set (or delete if empty) an in-memory overlay label."""
+        if not value:
+            self.delete(key)
+            return
+        self._overlays[key] = value
+
+    def delete(self, key: str) -> None:
+        """Remove an in-memory overlay label."""
+        self._overlays.pop(key, None)
+
     def start(self, node_data: tuple[str, ...] | None) -> str | None:
         """Begin a rename for the given node data.
 
-        Returns the current custom label (or empty string) if a rename can start,
-        or None if the node data does not support renaming.
+        Returns the current overlay label (or empty string) if a rename can
+        start, or None if the node data does not support renaming.
         """
         if node_data is None:
             return None
@@ -151,20 +170,34 @@ class RenameController:
             self._key = f"{session.session_name}.{window.window_index}.{pane.pane_index}"
         else:
             return None
-        return self._label_store.get(self._key)
+        return self.get(self._key)
 
     def finish(self, value: str) -> str | None:
         """Commit the rename and return the affected key, or None."""
         key = self._key
         if key is None:
             return None
-        if value:
-            self._label_store.set(key, value)
-        else:
-            self._label_store.delete(key)
+        self.set(key, value)
         self._key = None
         return key
 
     def cancel(self) -> None:
         """Abort the rename without saving."""
         self._key = None
+
+    def apply(self, tree: TmuxTree) -> None:
+        """Apply in-memory overlay labels to a tree snapshot."""
+        for session in tree.sessions:
+            label = self._overlays.get(session.session_name)
+            if label is not None:
+                session.custom_label = label
+            for window in session.windows:
+                key = f"{session.session_name}.{window.window_index}"
+                label = self._overlays.get(key)
+                if label is not None:
+                    window.custom_label = label
+                for pane in window.panes:
+                    key = f"{session.session_name}.{window.window_index}.{pane.pane_index}"
+                    label = self._overlays.get(key)
+                    if label is not None:
+                        pane.custom_label = label

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -748,10 +748,9 @@ async def test_rename_key_shows_input(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_rename_submit_saves_label(tmp_path):
-    """Submitting a name in rename input should save it via LabelStore."""
+async def test_rename_submit_sets_overlay():
+    """Submitting a name in rename input should set an in-memory overlay."""
     from textual.widgets import Input
-    from muxpilot.label_store import LabelStore
 
     tree = make_tree(sessions=[
         make_session(session_name="work", session_id="$0", windows=[
@@ -760,8 +759,7 @@ async def test_rename_submit_saves_label(tmp_path):
             ])
         ])
     ])
-    store = LabelStore(config_path=tmp_path / "config.toml")
-    app = _patched_app(tree=tree, label_store=store)
+    app = _patched_app(tree=tree)
     async with app.run_test() as pilot:
         tw = app.query_one("#tmux-tree", TmuxTreeView)
         tw.focus()
@@ -778,14 +776,13 @@ async def test_rename_submit_saves_label(tmp_path):
         await pilot.press("enter")
         await pilot.pause()
 
-        assert store.get("work.0.0") == "my test runner"
+        assert app._rename_controller.get("work.0.0") == "my test runner"
 
 
 @pytest.mark.asyncio
-async def test_rename_empty_deletes_label(tmp_path):
-    """Submitting empty string should delete the custom label."""
+async def test_rename_empty_deletes_overlay():
+    """Submitting empty string should delete the in-memory overlay."""
     from textual.widgets import Input
-    from muxpilot.label_store import LabelStore
 
     tree = make_tree(sessions=[
         make_session(session_name="work", session_id="$0", windows=[
@@ -794,9 +791,8 @@ async def test_rename_empty_deletes_label(tmp_path):
             ])
         ])
     ])
-    store = LabelStore(config_path=tmp_path / "config.toml")
-    store.set("work.0.0", "old label")
-    app = _patched_app(tree=tree, label_store=store)
+    app = _patched_app(tree=tree)
+    app._rename_controller.set("work.0.0", "old label")
     async with app.run_test() as pilot:
         tw = app.query_one("#tmux-tree", TmuxTreeView)
         tw.focus()
@@ -813,14 +809,13 @@ async def test_rename_empty_deletes_label(tmp_path):
         await pilot.press("enter")
         await pilot.pause()
 
-        assert store.get("work.0.0") == ""
+        assert app._rename_controller.get("work.0.0") == ""
 
 
 @pytest.mark.asyncio
-async def test_rename_escape_cancels(tmp_path):
+async def test_rename_escape_cancels():
     """Pressing Escape during rename should cancel without saving."""
     from textual.widgets import Input
-    from muxpilot.label_store import LabelStore
 
     tree = make_tree(sessions=[
         make_session(session_name="work", session_id="$0", windows=[
@@ -829,8 +824,7 @@ async def test_rename_escape_cancels(tmp_path):
             ])
         ])
     ])
-    store = LabelStore(config_path=tmp_path / "config.toml")
-    app = _patched_app(tree=tree, label_store=store)
+    app = _patched_app(tree=tree)
     async with app.run_test() as pilot:
         tw = app.query_one("#tmux-tree", TmuxTreeView)
         tw.focus()
@@ -847,7 +841,7 @@ async def test_rename_escape_cancels(tmp_path):
         await pilot.press("escape")
         await pilot.pause()
 
-        assert store.get("work.0.0") == ""
+        assert app._rename_controller.get("work.0.0") == ""
         assert not ri.has_class("-active")
 
 

--- a/tests/test_rename_controller.py
+++ b/tests/test_rename_controller.py
@@ -1,0 +1,185 @@
+"""Tests for muxpilot.controllers.RenameController — in-memory overlay only."""
+
+from __future__ import annotations
+
+import pytest
+
+from muxpilot.controllers import RenameController
+from muxpilot.models import SessionInfo, WindowInfo, PaneInfo
+
+
+def make_node_data(node_type: str, session_name="work", window_index=0, pane_index=0):
+    """Create node_data tuple for RenameController.start()."""
+    session = SessionInfo(
+        session_name=session_name,
+        session_id="$0",
+        is_attached=True,
+        windows=[],
+    )
+    window = WindowInfo(
+        window_id="@0",
+        window_name="editor",
+        window_index=window_index,
+        is_active=True,
+        panes=[],
+    )
+    pane = PaneInfo(
+        pane_id="%0",
+        pane_index=pane_index,
+        current_command="bash",
+        current_path="/home/user",
+        is_active=True,
+        width=80,
+        height=24,
+    )
+    return (node_type, session, window, pane)
+
+
+class TestRenameControllerOverlay:
+    """RenameController stores labels only in memory (no persistence)."""
+
+    def test_get_returns_empty_when_no_overlay(self) -> None:
+        ctrl = RenameController()
+        assert ctrl.get("work") == ""
+
+    def test_set_and_get(self) -> None:
+        ctrl = RenameController()
+        ctrl.set("work", "My Project")
+        assert ctrl.get("work") == "My Project"
+
+    def test_set_overwrites_existing(self) -> None:
+        ctrl = RenameController()
+        ctrl.set("work", "old")
+        ctrl.set("work", "new")
+        assert ctrl.get("work") == "new"
+
+    def test_delete_removes_overlay(self) -> None:
+        ctrl = RenameController()
+        ctrl.set("work", "label")
+        ctrl.delete("work")
+        assert ctrl.get("work") == ""
+
+    def test_empty_value_treated_as_delete(self) -> None:
+        ctrl = RenameController()
+        ctrl.set("work", "label")
+        ctrl.set("work", "")
+        assert ctrl.get("work") == ""
+
+    def test_start_session_key(self) -> None:
+        ctrl = RenameController()
+        data = make_node_data("session", session_name="myproject")
+        current = ctrl.start(data)
+        assert ctrl.key == "myproject"
+        assert current == ""
+
+    def test_start_window_key(self) -> None:
+        ctrl = RenameController()
+        data = make_node_data("window", session_name="myproject", window_index=2)
+        current = ctrl.start(data)
+        assert ctrl.key == "myproject.2"
+        assert current == ""
+
+    def test_start_pane_key(self) -> None:
+        ctrl = RenameController()
+        data = make_node_data("pane", session_name="myproject", window_index=2, pane_index=1)
+        current = ctrl.start(data)
+        assert ctrl.key == "myproject.2.1"
+        assert current == ""
+
+    def test_start_returns_existing_overlay(self) -> None:
+        ctrl = RenameController()
+        ctrl.set("myproject", "Existing")
+        data = make_node_data("session", session_name="myproject")
+        current = ctrl.start(data)
+        assert current == "Existing"
+
+    def test_start_none_returns_none(self) -> None:
+        ctrl = RenameController()
+        assert ctrl.start(None) is None
+
+    def test_finish_sets_overlay(self) -> None:
+        ctrl = RenameController()
+        ctrl.start(make_node_data("session", session_name="work"))
+        result = ctrl.finish("New Label")
+        assert result == "work"
+        assert ctrl.get("work") == "New Label"
+
+    def test_finish_empty_deletes_overlay(self) -> None:
+        ctrl = RenameController()
+        ctrl.set("work", "Existing")
+        ctrl.start(make_node_data("session", session_name="work"))
+        result = ctrl.finish("")
+        assert result == "work"
+        assert ctrl.get("work") == ""
+
+    def test_finish_without_start_is_noop(self) -> None:
+        ctrl = RenameController()
+        assert ctrl.finish("x") is None
+
+    def test_cancel_clears_key_without_saving(self) -> None:
+        ctrl = RenameController()
+        ctrl.start(make_node_data("session", session_name="work"))
+        ctrl.cancel()
+        assert ctrl.key is None
+        assert ctrl.get("work") == ""
+
+    def test_apply_to_tree(self) -> None:
+        """apply() should set custom_label on the tree from overlays."""
+        from muxpilot.models import TmuxTree
+        from conftest import make_session, make_window, make_pane
+
+        tree = TmuxTree(sessions=[
+            make_session(session_name="work", session_id="$0", windows=[
+                make_window(window_name="editor", window_index=0, panes=[
+                    make_pane(pane_id="%0", pane_index=0),
+                ])
+            ])
+        ])
+
+        ctrl = RenameController()
+        ctrl.set("work", "Project A")
+        ctrl.set("work.0", "Editor Window")
+        ctrl.set("work.0.0", "Main Pane")
+
+        ctrl.apply(tree)
+
+        assert tree.sessions[0].custom_label == "Project A"
+        assert tree.sessions[0].windows[0].custom_label == "Editor Window"
+        assert tree.sessions[0].windows[0].panes[0].custom_label == "Main Pane"
+
+    def test_apply_skips_missing_overlays(self) -> None:
+        from muxpilot.models import TmuxTree
+        from conftest import make_session, make_window, make_pane
+
+        tree = TmuxTree(sessions=[
+            make_session(session_name="work", windows=[
+                make_window(window_index=0, panes=[make_pane(pane_index=0)])
+            ])
+        ])
+
+        ctrl = RenameController()
+        ctrl.apply(tree)
+
+        assert tree.sessions[0].custom_label == ""
+
+    def test_overlay_does_not_persist_across_instances(self) -> None:
+        ctrl1 = RenameController()
+        ctrl1.set("work", "temp")
+
+        ctrl2 = RenameController()
+        assert ctrl2.get("work") == ""
+
+    def test_overlay_overrides_store(self) -> None:
+        """When LabelStore and overlay both have a value, overlay wins."""
+        from pathlib import Path
+        from muxpilot.label_store import LabelStore
+        tmp_path = Path("/tmp/muxpilot_test_ctrl")
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        config = tmp_path / "config.toml"
+        store = LabelStore(config_path=config)
+        store.set("work", "Stored Label")
+
+        ctrl = RenameController()
+        # Simulate applying both sources: store first, then overlay
+        ctrl.set("work", "Overlay Label")
+        assert ctrl.get("work") == "Overlay Label"


### PR DESCRIPTION
## Summary
- `n` キーによる rename を config (`~/.config/muxpilot/config.toml`) に保存しない、純粋なメモリ内オーバーレイに変更します。
- プロセス終了とともに rename 内容は消失します。

## Changes
- **RenameController**: `LabelStore` への依存を完全に削除し、`dict[str, str]` によるメモリ内オーバーレイに変更
  - `get/set/delete/apply(tree)` を追加
  - `finish()` は `_overlays` にのみ書き込み（TOML ファイルには触れない）
- **App**: `RenameController` の初期化から `LabelStore` を除去
- **`_apply_labels()`**: `LabelStore` の既存ラベルを読み込んだ後、`RenameController.apply(tree)` を呼び出してメモリ内オーバーレイを優先適用
- **Tests**: `tests/test_rename_controller.py` を新規作成（18 tests）、`test_app.py` の rename テストを新動作に合わせて修正

## Why
rename の結果が config に書き込まれると、以下の問題が生じていました：
- Session 名に `.` を含む場合、`session` ラベルと `window` ラベルの key が衝突する（例: session `a.1` と session `a` の window_index=1 がどちらも key `a.1`）
- window/pane の index は動的に変わるため、インデックスベースの key は永続化に向かない
- 一時的な表示名変更が config に残り続けると、手動で削除する手間が生じる

メモリ内オーバーレイにすることで、これらの問題を根本的に解消し、利用者にとっての「今だけの表示名変更」という UX に近づけます。