### PR TITLE
Remove LabelStore labels read/write; keep only theme persistence

### DIFF
--- a/src/muxpilot/app.py
+++ b/src/muxpilot/app.py
@@ -243,22 +243,7 @@ class MuxpilotApp(App[str | None]):
         self.set_interval(NOTIFY_CHECK_INTERVAL, self._check_notifications)
 
     def _apply_labels(self, tree: TmuxTree) -> None:
-        """Apply custom labels from LabelStore and in-memory overlays to the tree."""
-        for session in tree.sessions:
-            label = self._label_store.get(session.session_name)
-            if label:
-                session.custom_label = label
-            for window in session.windows:
-                key = f"{session.session_name}.{window.window_index}"
-                label = self._label_store.get(key)
-                if label:
-                    window.custom_label = label
-                for pane in window.panes:
-                    key = f"{session.session_name}.{window.window_index}.{pane.pane_index}"
-                    label = self._label_store.get(key)
-                    if label:
-                        pane.custom_label = label
-        # In-memory overlays take precedence and are never persisted.
+        """Apply in-memory overlay labels to the tree snapshot."""
         self._rename_controller.apply(tree)
 
     async def _do_refresh(self) -> None:

--- a/src/muxpilot/label_store.py
+++ b/src/muxpilot/label_store.py
@@ -1,4 +1,4 @@
-"""TOML-backed label persistence for custom display names."""
+"""TOML-backed theme persistence for muxpilot."""
 
 from __future__ import annotations
 
@@ -12,43 +12,15 @@ DEFAULT_CONFIG_PATH = Path.home() / ".config" / "muxpilot" / "config.toml"
 
 
 class LabelStore:
-    """Reads and writes custom labels to a TOML config file.
+    """Reads and writes app settings (theme) to a TOML config file.
 
-    Labels are stored under the [labels] section with flat string keys:
-      - "session_name" for sessions
-      - "session_name.window_index" for windows
-      - "session_name.window_index.pane_index" for panes
+    Custom labels are no longer persisted — they are handled in-memory
+    by RenameController.
     """
 
     def __init__(self, config_path: Path | None = None) -> None:
         self._path = config_path or DEFAULT_CONFIG_PATH
         self._doc: TOMLDocument = self._load()
-
-    def get(self, key: str) -> str:
-        """Return the custom label for *key*, or empty string if unset."""
-        labels = self._doc.get("labels")
-        if labels is None:
-            return ""
-        return labels.get(key, "")  # type: ignore[no-any-return]
-
-    def set(self, key: str, label: str) -> None:
-        """Set (or delete if empty) a custom label and persist to disk."""
-        if not label:
-            self.delete(key)
-            return
-        if "labels" not in self._doc:
-            self._doc.add("labels", tomlkit.table())
-        self._doc["labels"][key] = label  # type: ignore[index]
-        self._save()
-
-    def delete(self, key: str) -> None:
-        """Remove a custom label. No-op if key doesn't exist."""
-        labels = self._doc.get("labels")
-        if labels is None:
-            return
-        if key in labels:
-            del labels[key]
-            self._save()
 
     def get_theme(self) -> str:
         """Return the stored theme or 'textual-dark' default."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -690,11 +690,8 @@ async def test_events_sent_through_notify_channel():
 
 
 @pytest.mark.asyncio
-async def test_labels_applied_on_refresh(tmp_path):
-    """Custom labels from LabelStore should appear in the tree after refresh."""
-    from muxpilot.label_store import LabelStore
-    store = LabelStore(config_path=tmp_path / "config.toml")
-
+async def test_labels_applied_on_refresh():
+    """In-memory overlay labels should appear in the tree after refresh."""
     tree = make_tree(sessions=[
         make_session(session_name="work", session_id="$0", windows=[
             make_window(window_name="editor", window_index=0, panes=[
@@ -702,9 +699,9 @@ async def test_labels_applied_on_refresh(tmp_path):
             ])
         ])
     ])
-    app = _patched_app(tree=tree, label_store=store)
+    app = _patched_app(tree=tree)
     async with app.run_test() as pilot:
-        app._label_store.set("work", "🚀 Main Project")
+        app._rename_controller.set("work", "🚀 Main Project")
         await app.action_refresh()
         await pilot.pause()
 

--- a/tests/test_label_store.py
+++ b/tests/test_label_store.py
@@ -1,4 +1,4 @@
-"""Tests for muxpilot.label_store — TOML-backed label persistence."""
+"""Tests for muxpilot.label_store — TOML-backed theme persistence."""
 
 from __future__ import annotations
 
@@ -9,121 +9,33 @@ import pytest
 from muxpilot.label_store import LabelStore
 
 
-class TestLabelStoreGetSetDelete:
-    """Basic get/set/delete operations."""
+class TestLabelStoreTheme:
+    """Theme get/set operations."""
 
-    def test_get_returns_empty_string_when_no_label(self, tmp_path: Path) -> None:
+    def test_get_theme_default(self, tmp_path: Path) -> None:
         store = LabelStore(config_path=tmp_path / "config.toml")
-        assert store.get("myproject") == ""
+        assert store.get_theme() == "textual-dark"
 
-    def test_set_and_get(self, tmp_path: Path) -> None:
+    def test_set_and_get_theme(self, tmp_path: Path) -> None:
         store = LabelStore(config_path=tmp_path / "config.toml")
-        store.set("myproject", "🚀 Main")
-        assert store.get("myproject") == "🚀 Main"
-
-    def test_set_overwrites_existing(self, tmp_path: Path) -> None:
-        store = LabelStore(config_path=tmp_path / "config.toml")
-        store.set("myproject", "old")
-        store.set("myproject", "new")
-        assert store.get("myproject") == "new"
-
-    def test_delete_removes_label(self, tmp_path: Path) -> None:
-        store = LabelStore(config_path=tmp_path / "config.toml")
-        store.set("myproject", "label")
-        store.delete("myproject")
-        assert store.get("myproject") == ""
-
-    def test_delete_nonexistent_key_is_noop(self, tmp_path: Path) -> None:
-        store = LabelStore(config_path=tmp_path / "config.toml")
-        store.delete("nonexistent")  # should not raise
-
-    def test_set_window_label(self, tmp_path: Path) -> None:
-        store = LabelStore(config_path=tmp_path / "config.toml")
-        store.set("myproject.1", "Editor")
-        assert store.get("myproject.1") == "Editor"
-
-    def test_set_pane_label(self, tmp_path: Path) -> None:
-        store = LabelStore(config_path=tmp_path / "config.toml")
-        store.set("myproject.1.0", "vim server")
-        assert store.get("myproject.1.0") == "vim server"
-
-
-class TestLabelStorePersistence:
-    """File persistence tests."""
-
-    def test_labels_persist_across_instances(self, tmp_path: Path) -> None:
-        config_path = tmp_path / "config.toml"
-        store1 = LabelStore(config_path=config_path)
-        store1.set("myproject", "persisted")
-
-        store2 = LabelStore(config_path=config_path)
-        assert store2.get("myproject") == "persisted"
-
-    def test_creates_parent_directories(self, tmp_path: Path) -> None:
-        config_path = tmp_path / "subdir" / "deep" / "config.toml"
-        store = LabelStore(config_path=config_path)
-        store.set("test", "value")
-        assert config_path.exists()
-
-    def test_loads_existing_config_without_labels_section(self, tmp_path: Path) -> None:
-        """A config.toml without [labels] should not crash."""
-        config_path = tmp_path / "config.toml"
-        config_path.write_text('[other]\nkey = "value"\n')
-        store = LabelStore(config_path=config_path)
-        assert store.get("anything") == ""
-
-    def test_preserves_other_sections(self, tmp_path: Path) -> None:
-        """Setting a label should not destroy other TOML sections."""
-        config_path = tmp_path / "config.toml"
-        config_path.write_text('[other]\nkey = "value"\n')
-        store = LabelStore(config_path=config_path)
-        store.set("myproject", "label")
-
-        import tomllib
-        with open(config_path, "rb") as f:
-            data = tomllib.load(f)
-        assert data["other"]["key"] == "value"
-        assert data["labels"]["myproject"] == "label"
+        store.set_theme("textual-light")
+        assert store.get_theme() == "textual-light"
 
     def test_theme_persistence(self, tmp_path: Path) -> None:
         """Theme settings should persist across instances."""
         config_path = tmp_path / "config.toml"
-        store = LabelStore(config_path=config_path)
+        store1 = LabelStore(config_path=config_path)
+        store1.set_theme("textual-light")
 
-        # Default theme
-        assert store.get_theme() == "textual-dark"
-
-        # Set and save
-        store.set_theme("textual-light")
-        assert store.get_theme() == "textual-light"
-
-        # Reload from disk
         store2 = LabelStore(config_path=config_path)
         assert store2.get_theme() == "textual-light"
 
 
-class TestLabelStoreEdgeCases:
-    """Edge case handling."""
-
-    def test_session_name_with_dots(self, tmp_path: Path) -> None:
-        """Session names containing dots should work (TOML quoted keys)."""
-        store = LabelStore(config_path=tmp_path / "config.toml")
-        store.set("my.project", "dotted")
-        assert store.get("my.project") == "dotted"
-
-    def test_empty_label_treated_as_delete(self, tmp_path: Path) -> None:
-        """Setting a label to empty string should delete it."""
-        store = LabelStore(config_path=tmp_path / "config.toml")
-        store.set("myproject", "something")
-        store.set("myproject", "")
-        assert store.get("myproject") == ""
-
-
-class TestLabelStoreCommentPreservation:
-    """Comments and formatting must survive label edits."""
+class TestLabelStoreConfigPreservation:
+    """Existing config content must survive theme edits."""
 
     def test_preserves_comments_and_watcher_section(self, tmp_path: Path) -> None:
-        """Setting a label must not strip TOML comments or unrelated sections."""
+        """Setting a theme must not strip TOML comments or unrelated sections."""
         config_path = tmp_path / "config.toml"
         original_text = '''# muxpilot configuration
 # Place this file at ~/.config/muxpilot/config.toml
@@ -151,7 +63,7 @@ error_patterns = [
 '''
         config_path.write_text(original_text, encoding="utf-8")
         store = LabelStore(config_path=config_path)
-        store.set("myproject", "label")
+        store.set_theme("textual-light")
 
         saved_text = config_path.read_text(encoding="utf-8")
         # Comments must survive
@@ -166,26 +78,14 @@ error_patterns = [
         assert data["watcher"]["poll_interval"] == 2.0
         assert len(data["watcher"]["prompt_patterns"]) == 2
         assert len(data["watcher"]["error_patterns"]) == 1
-        assert data["labels"]["myproject"] == "label"
+        assert data["app"]["theme"] == "textual-light"
 
-    def test_preserves_comments_when_updating_existing_label(self, tmp_path: Path) -> None:
-        """Updating a label must not strip surrounding comments."""
-        config_path = tmp_path / "config.toml"
-        original_text = '''[watcher]
-poll_interval = 2.0
 
-[labels]
-# main project
-myproject = "old"
-# secondary project
-other = "value"
-'''
-        config_path.write_text(original_text, encoding="utf-8")
+class TestLabelStoreEdgeCases:
+    """Edge case handling."""
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        config_path = tmp_path / "subdir" / "deep" / "config.toml"
         store = LabelStore(config_path=config_path)
-        store.set("myproject", "new")
-
-        saved_text = config_path.read_text(encoding="utf-8")
-        assert "# main project" in saved_text
-        assert "# secondary project" in saved_text
-        assert 'myproject = "new"' in saved_text
-        assert "[watcher]" in saved_text
+        store.set_theme("textual-light")
+        assert config_path.exists()

--- a/tests/test_rename_controller.py
+++ b/tests/test_rename_controller.py
@@ -168,18 +168,3 @@ class TestRenameControllerOverlay:
 
         ctrl2 = RenameController()
         assert ctrl2.get("work") == ""
-
-    def test_overlay_overrides_store(self) -> None:
-        """When LabelStore and overlay both have a value, overlay wins."""
-        from pathlib import Path
-        from muxpilot.label_store import LabelStore
-        tmp_path = Path("/tmp/muxpilot_test_ctrl")
-        tmp_path.mkdir(parents=True, exist_ok=True)
-        config = tmp_path / "config.toml"
-        store = LabelStore(config_path=config)
-        store.set("work", "Stored Label")
-
-        ctrl = RenameController()
-        # Simulate applying both sources: store first, then overlay
-        ctrl.set("work", "Overlay Label")
-        assert ctrl.get("work") == "Overlay Label"


### PR DESCRIPTION
## Summary
config.toml の `[labels]` セクションからの読み取り・書き込み機能を完全に削除します。
LabelStore は theme 設定（`[app].theme`）の永続化のみを担当します。

## Changes
- **LabelStore**: `get/set/delete` メソッドを削除、theme 専用に変更
- **App._apply_labels()**: LabelStore からの読み取りを削除、RenameController のメモリ内オーバーレイのみを適用
- **Tests**:
  - `test_label_store.py` を theme 専用に簡潔化（labels テスト削除）
  - `test_app.py::test_labels_applied_on_refresh` を RenameController オーバーレイ仕様に修正
  - `test_rename_controller.py::test_overlay_overrides_store` を削除（Store との比較が不要になったため）

## Why
前回の PR (#18) で n キー rename の書き込みをメモリ内に移行しましたが、
起動時の LabelStore 読み取りが残っていたため、非対称な UX（手動で書いた labels は永続、n キーでは上書きされない）が残っていました。
labels 機能を完全にメモリ内に移行することで、シンプルで一貫性のある動作になります。