### PR TITLE
fix: reduce tmux server load with poll cooldown, retry limit, and longer interval

### DIFF
--- a/src/muxpilot/app.py
+++ b/src/muxpilot/app.py
@@ -317,6 +317,7 @@ class MuxpilotApp(App[str | None]):
         success = self._client.navigate_to(pane_id)
         if success:
             self._notify_channel.send(f"Navigated to {pane_id}")
+            self._polling.trigger_cooldown()
             await self._do_refresh()
         else:
             self._notify_channel.send(f"Failed to navigate to {pane_id}")
@@ -417,6 +418,7 @@ class MuxpilotApp(App[str | None]):
                 success = self._client.kill_pane(pane.pane_id)
                 msg = f"Killed pane {label}" if success else f"Failed to kill pane {label}"
                 self._notify_channel.send(msg)
+                self._polling.trigger_cooldown()
                 asyncio.create_task(self._do_refresh())
 
         self.push_screen(

--- a/src/muxpilot/controllers.py
+++ b/src/muxpilot/controllers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 
 from muxpilot.models import PaneStatus, TmuxEvent, TmuxTree
 from muxpilot.tmux_client import TmuxClient
@@ -10,6 +11,8 @@ from muxpilot.watcher import TmuxWatcher
 
 
 MAX_POLL_BACKOFF_SECONDS = 30.0
+DEFAULT_MAX_CONSECUTIVE_FAILURES = 5
+DEFAULT_COOLDOWN_SECONDS = 2.0
 
 
 class PollingController:
@@ -27,6 +30,9 @@ class PollingController:
         self._backoff = watcher.poll_interval
         self._poll_timer = None
         self._retry_timer = None
+        self.cooldown_until = 0.0
+        self.consecutive_failures = 0
+        self.max_consecutive_failures = DEFAULT_MAX_CONSECUTIVE_FAILURES
 
     @property
     def backoff(self) -> float:
@@ -65,14 +71,29 @@ class PollingController:
         if self._retry_timer is not None:
             self._retry_timer.stop()
 
+    def trigger_cooldown(self, seconds: float = DEFAULT_COOLDOWN_SECONDS) -> None:
+        """Suppress polling for *seconds* to avoid racing with tmux operations."""
+        self.cooldown_until = time.time() + seconds
+
     async def tick(self) -> tuple[TmuxTree, list[TmuxEvent]] | None:
         """Execute one poll cycle with error handling and backoff.
 
-        Returns (tree, events) on success, or None on failure (backoff applied).
+        Returns (tree, events) on success, or None on failure / cooldown.
         """
+        if time.time() < self.cooldown_until:
+            return None
+
         try:
             tree, events = await asyncio.to_thread(self._watcher.poll)
         except Exception as e:
+            self.consecutive_failures += 1
+            if self.consecutive_failures >= self.max_consecutive_failures:
+                self._notify.send(
+                    f"tmux polling stopped after {self.consecutive_failures} consecutive failures"
+                )
+                self.stop()
+                return None
+
             if self._watcher.notify_poll_errors:
                 self._notify.send(f"tmux poll failed: {e}; retrying in {self._backoff}s")
             self._backoff = min(self._backoff * 2, MAX_POLL_BACKOFF_SECONDS)
@@ -85,6 +106,7 @@ class PollingController:
             )
             return None
 
+        self.consecutive_failures = 0
         self._backoff = self._watcher.poll_interval
         if self._poll_timer is not None:
             self._poll_timer.resume()

--- a/src/muxpilot/watcher.py
+++ b/src/muxpilot/watcher.py
@@ -41,7 +41,7 @@ DEFAULT_ERROR_PATTERNS: list[re.Pattern[str]] = [
 
 # Idle threshold in seconds before a pane is considered idle
 DEFAULT_IDLE_THRESHOLD: float = 10.0
-DEFAULT_POLL_INTERVAL: float = 2.0
+DEFAULT_POLL_INTERVAL: float = 5.0
 
 
 class TmuxWatcher:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,6 +9,8 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from muxpilot.models import PaneStatus
+import pathlib
+
 from muxpilot.app import MuxpilotApp, MAX_POLL_BACKOFF_SECONDS, main
 from muxpilot.screens.help_screen import HelpScreen
 from muxpilot.watcher import DEFAULT_POLL_INTERVAL
@@ -23,7 +25,7 @@ def _patched_app(tree=None, current_pane_id=None, label_store=None, config_error
     app = MuxpilotApp()
     app._client = mock_client
     from muxpilot.watcher import TmuxWatcher
-    app._watcher = TmuxWatcher(mock_client)
+    app._watcher = TmuxWatcher(mock_client, config_path=pathlib.Path("/nonexistent-muxpilot-config"))
     app._notify_channel = make_mock_notify_channel()
     if config_error is not None:
         app._watcher._config_error = config_error
@@ -973,3 +975,86 @@ def test_main_outside_tmux_attaches_even_if_session_exists(mock_client_cls, mock
     mock_execlp.assert_called_once_with(
         "tmux", "tmux", "attach", "-t", "muxpilot"
     )
+
+
+# ============================================================================
+# Polling cooldown
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_poll_cooldown_skips_tick():
+    """When cooldown is active, tick() should return None without polling."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])
+    ])
+    app = _patched_app(tree=tree)
+    async with app.run_test():
+        app._polling.trigger_cooldown(60.0)
+        result = await app._polling.tick()
+        assert result is None
+
+
+@pytest.mark.asyncio
+async def test_poll_retry_limit_stops_polling():
+    """After max_consecutive_failures, polling should stop and notify."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])
+    ])
+    app = _patched_app(tree=tree)
+    async with app.run_test() as pilot:
+        app._watcher.poll = MagicMock(side_effect=RuntimeError("tmux down"))
+        app._poll_timer = MagicMock()
+        app._polling.max_consecutive_failures = 3
+
+        for _ in range(3):
+            with patch.object(app, "set_interval"):
+                await app._poll_tmux()
+
+        app._poll_timer.stop.assert_called_once()
+        messages = [call.args[0] for call in app._notify_channel.send.call_args_list if call.args]
+        assert any("stopped after 3 consecutive failures" in m for m in messages)
+
+
+# ============================================================================
+# Cooldown triggered by user actions
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_navigate_triggers_cooldown():
+    """Navigating to a pane should trigger polling cooldown."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0", is_active=False)])])
+    ])
+    app = _patched_app(tree=tree, current_pane_id="%99")
+    async with app.run_test():
+        app._polling.trigger_cooldown = MagicMock()
+        msg = TmuxTreeView.PaneActivated(pane_id="%0")
+        await app.on_tmux_tree_view_pane_activated(msg)
+        app._polling.trigger_cooldown.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_kill_triggers_cooldown():
+    """Killing a pane should trigger polling cooldown."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0", is_active=False)])])
+    ])
+    app = _patched_app(tree=tree, current_pane_id="%99")
+    async with app.run_test() as pilot:
+        tw = app.query_one("#tmux-tree", TmuxTreeView)
+        tw.focus()
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.press("j")
+        await pilot.pause()
+
+        app.action_kill_pane()
+        await pilot.pause()
+
+        app._polling.trigger_cooldown = MagicMock()
+        await pilot.press("y")
+        await pilot.pause()
+
+        app._polling.trigger_cooldown.assert_called_once()

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -12,13 +12,15 @@ from muxpilot.watcher import TmuxWatcher
 from conftest import make_mock_client, make_pane, make_session, make_tree, make_window
 
 
+import pathlib
+
 def _make_watcher(
-    tree=None, capture=None, current_pane_id=None, idle_threshold=10.0
+    tree=None, capture=None, current_pane_id=None, idle_threshold=10.0, config_path=pathlib.Path("/nonexistent-muxpilot-config")
 ):
     client = make_mock_client(
         tree=tree, capture_content=capture, current_pane_id=current_pane_id
     )
-    return TmuxWatcher(client, idle_threshold=idle_threshold)
+    return TmuxWatcher(client, idle_threshold=idle_threshold, config_path=config_path)
 
 
 class TestDetermineStatus:


### PR DESCRIPTION
## 背景
pane 移動中に tmux server の CPU が 100% になってハングする問題が報告されました。

## 原因（推定）
- デフォルトの poll 間隔が 2.0 秒と短く、pane 移動中の tmux server とポーリングが衝突する可能性が高い
- navigate_to / kill_pane 後に即座に poll が走り、server の状態が不安定な段階で tmux コマンドを発行していた
- poll 失敗時のリトライに上限がなく、server 不安定時に負荷をかけ続ける構造だった

## 対策
1. **poll 間隔を 5.0 秒に延長** — 衝突確率を下げる
2. **tmux 操作後のクールダウン** — `navigate_to()` / `kill_pane()` 後に 2 秒間 poll を抑制
3. **リトライ上限を導入** — 連続 5 回失敗で polling を停止し、負荷スパイラルを防止

## テスト
- 既存テスト 174 件 + 新規テスト 4 件 = **全 178 件パス**
- 付帯修正: テストが `~/.config/muxpilot/config.toml` に依存していた環境依存バグも修正