### PR TITLE
feat: pane detail panel with agent context (title, repo, branch, preview)

### DIFF
--- a/src/muxpilot/app.py
+++ b/src/muxpilot/app.py
@@ -110,7 +110,7 @@ class MuxpilotApp(App[str | None]):
         self._notify_config_error()
 
         self._filter_state = FilterState()
-        self._rename_controller = RenameController()
+        self._rename_controller = RenameController(self._client)
         self._polling = PollingController(
             self, self._watcher_instance, self._notify_channel_instance
         )

--- a/src/muxpilot/controllers.py
+++ b/src/muxpilot/controllers.py
@@ -129,13 +129,14 @@ class FilterState:
 class RenameController:
     """Manages the in-progress rename operation for a tree node.
 
-    Labels are kept only in memory (overlays).  They are never persisted to
-    disk — when the muxpilot process exits the overlays are lost.
+    Pane renames are applied directly to tmux via TmuxClient.set_pane_title().
+    Session/window renaming is not supported.
     """
 
-    def __init__(self) -> None:
-        self._overlays: dict[str, str] = {}
+    def __init__(self, client=None) -> None:
+        self._client = client
         self._key: str | None = None
+        self._pane_id: str | None = None
 
     @property
     def key(self) -> str | None:
@@ -145,66 +146,36 @@ class RenameController:
     def key(self, value: str | None) -> None:
         self._key = value
 
-    def get(self, key: str) -> str:
-        """Return the in-memory overlay label for *key*, or empty string."""
-        return self._overlays.get(key, "")
-
-    def set(self, key: str, value: str) -> None:
-        """Set (or delete if empty) an in-memory overlay label."""
-        if not value:
-            self.delete(key)
-            return
-        self._overlays[key] = value
-
-    def delete(self, key: str) -> None:
-        """Remove an in-memory overlay label."""
-        self._overlays.pop(key, None)
-
     def start(self, node_data: tuple[str, ...] | None) -> str | None:
         """Begin a rename for the given node data.
 
-        Returns the current overlay label (or empty string) if a rename can
+        Returns the current pane_title (or empty string) if a rename can
         start, or None if the node data does not support renaming.
         """
         if node_data is None:
             return None
         node_type, session, window, pane = node_data
-        if node_type == "session" and session:
-            self._key = session.session_name
-        elif node_type == "window" and session and window:
-            self._key = f"{session.session_name}.{window.window_index}"
-        elif node_type == "pane" and session and window and pane:
+        if node_type == "pane" and session and window and pane:
             self._key = f"{session.session_name}.{window.window_index}.{pane.pane_index}"
-        else:
-            return None
-        return self.get(self._key)
+            self._pane_id = pane.pane_id
+            return pane.pane_title
+        return None
 
     def finish(self, value: str) -> str | None:
         """Commit the rename and return the affected key, or None."""
         key = self._key
-        if key is None:
+        if key is None or self._client is None:
             return None
-        self.set(key, value)
+        self._client.set_pane_title(self._pane_id or "", value)
         self._key = None
+        self._pane_id = None
         return key
 
     def cancel(self) -> None:
         """Abort the rename without saving."""
         self._key = None
+        self._pane_id = None
 
     def apply(self, tree: TmuxTree) -> None:
-        """Apply in-memory overlay labels to a tree snapshot."""
-        for session in tree.sessions:
-            label = self._overlays.get(session.session_name)
-            if label is not None:
-                session.custom_label = label
-            for window in session.windows:
-                key = f"{session.session_name}.{window.window_index}"
-                label = self._overlays.get(key)
-                if label is not None:
-                    window.custom_label = label
-                for pane in window.panes:
-                    key = f"{session.session_name}.{window.window_index}.{pane.pane_index}"
-                    label = self._overlays.get(key)
-                    if label is not None:
-                        pane.custom_label = label
+        """No-op: pane_title comes from tmux directly on next poll."""
+        pass

--- a/src/muxpilot/models.py
+++ b/src/muxpilot/models.py
@@ -39,11 +39,18 @@ class PaneInfo:
     is_self: bool = False
     custom_label: str = ""
     full_command: str = ""
+    pane_title: str = ""
+    repo_name: str = ""
+    branch: str = ""
+    idle_seconds: float = 0.0
+    recent_lines: list[str] = field(default_factory=list)
 
     @property
     def display_label(self) -> str:
         """Label for tree view display."""
         icon = STATUS_ICONS.get(self.status, "?")
+        if self.pane_title:
+            return f"{icon} {self.pane_title}"
         if self.custom_label:
             return f"{icon} {self.custom_label}"
 
@@ -139,6 +146,7 @@ class PaneActivity:
     idle_seconds: float = 0.0
     status: PaneStatus = PaneStatus.ACTIVE
     content_changed: bool = False
+    recent_lines: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/muxpilot/tmux_client.py
+++ b/src/muxpilot/tmux_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 import time
 
 import libtmux
@@ -75,7 +76,11 @@ class TmuxClient:
                         height=int(pane.pane_height or 0),
                         is_self=(pane_id == self_pane_id),
                         full_command=self._get_full_command(pane),
+                        pane_title=pane.pane_title or "",
                     )
+                    git_info = self._get_git_info(pane_info.current_path)
+                    pane_info.repo_name = git_info["repo_name"]
+                    pane_info.branch = git_info["branch"]
                     window_info.panes.append(pane_info)
 
                 session_info.windows.append(window_info)
@@ -147,6 +152,34 @@ class TmuxClient:
             return []
         except libtmux.exc.LibTmuxException:
             return []
+
+    def _get_git_info(self, path: str) -> dict[str, str]:
+        """Get repository name and current branch for a path."""
+        result = {"repo_name": "", "branch": ""}
+        if not path:
+            return result
+        try:
+            top = subprocess.run(
+                ["git", "-C", path, "rev-parse", "--show-toplevel"],
+                capture_output=True, text=True, timeout=1.0, check=True,
+            ).stdout.strip()
+            result["repo_name"] = top.split("/")[-1] if top else ""
+            branch = subprocess.run(
+                ["git", "-C", path, "branch", "--show-current"],
+                capture_output=True, text=True, timeout=1.0, check=True,
+            ).stdout.strip()
+            result["branch"] = branch
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+        return result
+
+    def set_pane_title(self, pane_id: str, title: str) -> bool:
+        """Set the tmux pane title."""
+        try:
+            self.server.cmd("select-pane", "-t", pane_id, "-T", title)
+            return True
+        except Exception:
+            return False
 
     def _find_pane(self, pane_id: str) -> libtmux.Pane | None:
         """Find a pane object by its ID across all sessions.

--- a/src/muxpilot/watcher.py
+++ b/src/muxpilot/watcher.py
@@ -54,11 +54,13 @@ class TmuxWatcher:
         capture_lines: int = 30,
         config_path: pathlib.Path | None = None,
         poll_interval: float = DEFAULT_POLL_INTERVAL,
+        preview_lines: int = 5,
     ) -> None:
         self.client = client
         self.idle_threshold = idle_threshold
         self.capture_lines = capture_lines
         self.poll_interval = poll_interval
+        self.preview_lines = preview_lines
         self.activities: dict[str, PaneActivity] = {}
         self._config_error: str | None = None
         self.notify_poll_errors: bool = True
@@ -159,6 +161,8 @@ class TmuxWatcher:
                 )
 
             pane.status = new_activity.status
+            pane.idle_seconds = new_activity.idle_seconds
+            pane.recent_lines = new_activity.recent_lines
             self.activities[pane.pane_id] = new_activity
 
         # Clean up activities for removed panes
@@ -182,6 +186,7 @@ class TmuxWatcher:
         content_str = "\n".join(content)
         content_hash = hashlib.md5(content_str.encode()).hexdigest()
         last_line = content[-1].strip() if content else ""
+        recent_lines = content[-self.preview_lines:] if content else []
 
         content_changed = not (old_activity and old_activity.last_content_hash == content_hash)
 
@@ -197,6 +202,7 @@ class TmuxWatcher:
             idle_seconds=idle_seconds,
             status=old_activity.status if old_activity else PaneStatus.ACTIVE,
             content_changed=content_changed,
+            recent_lines=recent_lines,
         )
 
     def _determine_status(

--- a/src/muxpilot/widgets/detail_panel.py
+++ b/src/muxpilot/widgets/detail_panel.py
@@ -13,6 +13,7 @@ from muxpilot.models import (
     STATUS_ICONS,
     SessionInfo,
     WindowInfo,
+    _shorten_path,
 )
 
 
@@ -52,16 +53,39 @@ class DetailPanel(Widget):
         """Display pane details."""
         icon = STATUS_ICONS.get(pane.status, "?")
         status_name = pane.status.value if pane.status else "unknown"
+        idle_text = f" ({pane.idle_seconds:.1f}s idle)" if pane.idle_seconds > 0 else ""
+        title = pane.pane_title or "—"
+        repo = pane.repo_name or "—"
+        branch = pane.branch or "—"
 
         text = (
             f"[bold $accent]── Pane ──[/]\n"
             f"\n"
-            f"  [dim]ID:[/]        {pane.pane_id}\n"
-            f"  [dim]Command:[/]   {pane.current_command}\n"
-            f"  [dim]Path:[/]      {pane.current_path}\n"
-            f"  [dim]Size:[/]      {pane.width}×{pane.height}\n"
-            f"  [dim]Active:[/]    {'Yes' if pane.is_active else 'No'}\n"
-            f"  [dim]Status:[/]    {icon} {status_name}\n"
+            f"  [dim]Title:[/]       {title}\n"
+            f"  [dim]Repository:[/]  {repo}\n"
+            f"  [dim]Branch:[/]      {branch}\n"
+            f"  [dim]Command:[/]     {pane.full_command or pane.current_command}\n"
+            f"  [dim]Path:[/]        {_shorten_path(pane.current_path)}\n"
+            f"  [dim]Size:[/]        {pane.width}×{pane.height}\n"
+            f"  [dim]Active:[/]      {'Yes' if pane.is_active else 'No'}\n"
+            f"  [dim]Status:[/]      {icon} {status_name}{idle_text}\n"
+        )
+
+        if pane.status == PaneStatus.ERROR:
+            text += "\n  [bold $error]Status is ERROR[/]\n"
+        elif pane.status == PaneStatus.WAITING_INPUT:
+            text += "\n  [bold $warning]Waiting for input[/]\n"
+
+        text += (
+            f"\n"
+            f"[bold $accent]── Recent Output ──[/]\n"
+        )
+        preview = pane.recent_lines if pane.recent_lines else ["(no output)"]
+        for line in preview:
+            safe = line if line.strip() else "(blank)"
+            text += f"  {safe}\n"
+
+        text += (
             f"\n"
             f"  [dim]Window:[/]    {window.window_name} (#{window.window_index})\n"
             f"  [dim]Session:[/]   {session.session_name}\n"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,10 @@ def make_pane(
     is_self: bool = False,
     custom_label: str = "",
     full_command: str = "",
+    pane_title: str = "",
+    repo_name: str = "",
+    branch: str = "",
+    idle_seconds: float = 0.0,
 ) -> PaneInfo:
     """Create a PaneInfo with sensible defaults."""
     return PaneInfo(
@@ -41,6 +45,10 @@ def make_pane(
         is_self=is_self,
         custom_label=custom_label,
         full_command=full_command,
+        pane_title=pane_title,
+        repo_name=repo_name,
+        branch=branch,
+        idle_seconds=idle_seconds,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ def make_pane(
     repo_name: str = "",
     branch: str = "",
     idle_seconds: float = 0.0,
+    recent_lines: list[str] | None = None,
 ) -> PaneInfo:
     """Create a PaneInfo with sensible defaults."""
     return PaneInfo(
@@ -49,6 +50,7 @@ def make_pane(
         repo_name=repo_name,
         branch=branch,
         idle_seconds=idle_seconds,
+        recent_lines=recent_lines or [],
     )
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -67,6 +67,36 @@ async def test_tree_populated_on_mount():
 
 
 @pytest.mark.asyncio
+async def test_detail_panel_shows_pane_title_and_git():
+    """Detail panel should display pane title, repo, branch, and idle time."""
+    from muxpilot.widgets.detail_panel import DetailPanel
+    panel = DetailPanel()
+    session = make_session(session_name="dev", windows=[
+        make_window(window_name="editor", panes=[
+            make_pane(
+                pane_id="%0",
+                pane_title="agent-a",
+                repo_name="proj",
+                branch="feat/x",
+                idle_seconds=12.0,
+                status=PaneStatus.IDLE,
+                recent_lines=["line1", "line2"],
+            )
+        ])
+    ])
+    window = session.windows[0]
+    pane = window.panes[0]
+    panel.show_pane(pane, window, session)
+    text = str(panel._content.render())
+    assert "agent-a" in text
+    assert "proj" in text
+    assert "feat/x" in text
+    assert "12.0s idle" in text
+    assert "line1" in text
+    assert "line2" in text
+
+
+@pytest.mark.asyncio
 async def test_shows_warning_when_not_in_tmux():
     """App should show a warning when launched outside a tmux session."""
     app = _patched_app()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -24,6 +24,8 @@ def _patched_app(tree=None, current_pane_id=None, label_store=None, config_error
     mock_client = make_mock_client(tree=tree, current_pane_id=current_pane_id)
     app = MuxpilotApp()
     app._client = mock_client
+    from muxpilot.controllers import RenameController
+    app._rename_controller = RenameController(mock_client)
     from muxpilot.watcher import TmuxWatcher
     app._watcher = TmuxWatcher(mock_client, config_path=pathlib.Path("/nonexistent-muxpilot-config"))
     app._notify_channel = make_mock_notify_channel()
@@ -666,28 +668,6 @@ async def test_notify_channel_started_on_mount():
 # ============================================================================
 
 
-@pytest.mark.asyncio
-async def test_labels_applied_on_refresh():
-    """In-memory overlay labels should appear in the tree after refresh."""
-    tree = make_tree(sessions=[
-        make_session(session_name="work", session_id="$0", windows=[
-            make_window(window_name="editor", window_index=0, panes=[
-                make_pane(pane_id="%0", pane_index=0),
-            ])
-        ])
-    ])
-    app = _patched_app(tree=tree)
-    async with app.run_test() as pilot:
-        app._rename_controller.set("work", "🚀 Main Project")
-        await app._do_refresh()
-        await pilot.pause()
-
-        tw = app.query_one("#tmux-tree", TmuxTreeView)
-        for node_id, (node_type, session, window, pane) in tw._node_data.items():
-            if node_type == "session" and session:
-                assert session.custom_label == "🚀 Main Project"
-
-
 # ============================================================================
 # Custom labels: rename action (n key)
 # ============================================================================
@@ -722,8 +702,8 @@ async def test_rename_key_shows_input(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_rename_submit_sets_overlay():
-    """Submitting a name in rename input should set an in-memory overlay."""
+async def test_rename_submit_sets_pane_title():
+    """Submitting a name in rename input should call set_pane_title on the client."""
     from textual.widgets import Input
 
     tree = make_tree(sessions=[
@@ -750,12 +730,12 @@ async def test_rename_submit_sets_overlay():
         await pilot.press("enter")
         await pilot.pause()
 
-        assert app._rename_controller.get("work.0.0") == "my test runner"
+        app._client.set_pane_title.assert_called_with("%0", "my test runner")
 
 
 @pytest.mark.asyncio
-async def test_rename_empty_deletes_overlay():
-    """Submitting empty string should delete the in-memory overlay."""
+async def test_rename_empty_sets_empty_pane_title():
+    """Submitting empty string should call set_pane_title with empty string."""
     from textual.widgets import Input
 
     tree = make_tree(sessions=[
@@ -766,7 +746,6 @@ async def test_rename_empty_deletes_overlay():
         ])
     ])
     app = _patched_app(tree=tree)
-    app._rename_controller.set("work.0.0", "old label")
     async with app.run_test() as pilot:
         tw = app.query_one("#tmux-tree", TmuxTreeView)
         tw.focus()
@@ -783,12 +762,12 @@ async def test_rename_empty_deletes_overlay():
         await pilot.press("enter")
         await pilot.pause()
 
-        assert app._rename_controller.get("work.0.0") == ""
+        app._client.set_pane_title.assert_called_with("%0", "")
 
 
 @pytest.mark.asyncio
 async def test_rename_escape_cancels():
-    """Pressing Escape during rename should cancel without saving."""
+    """Pressing Escape during rename should cancel without calling set_pane_title."""
     from textual.widgets import Input
 
     tree = make_tree(sessions=[
@@ -815,7 +794,7 @@ async def test_rename_escape_cancels():
         await pilot.press("escape")
         await pilot.pause()
 
-        assert app._rename_controller.get("work.0.0") == ""
+        app._client.set_pane_title.assert_not_called()
         assert not ri.has_class("-active")
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -138,6 +138,20 @@ class TestPaneInfoDisplayLabel:
         assert "[]" not in label
         assert " — " in label
 
+    def test_display_label_prefers_pane_title(self) -> None:
+        pane = make_pane(pane_title="my-agent", custom_label="old-label", current_command="bash")
+        assert "my-agent" in pane.display_label
+        assert "old-label" not in pane.display_label
+
+    def test_display_label_fallback_to_custom_label(self) -> None:
+        pane = make_pane(pane_title="", custom_label="custom", current_command="bash")
+        assert "custom" in pane.display_label
+
+    def test_display_label_fallback_to_heuristic(self) -> None:
+        pane = make_pane(pane_title="", custom_label="", current_command="python", current_path="/home/user/proj")
+        assert "python" in pane.display_label
+        assert "user/proj" in pane.display_label
+
 
 # ============================================================================
 # WindowInfo.display_label

--- a/tests/test_rename_controller.py
+++ b/tests/test_rename_controller.py
@@ -31,100 +31,69 @@ def make_node_data(node_type: str, session_name="work", window_index=0, pane_ind
         is_active=True,
         width=80,
         height=24,
+        pane_title="",
     )
     return (node_type, session, window, pane)
 
 
-class TestRenameControllerOverlay:
-    """RenameController stores labels only in memory (no persistence)."""
+class TestRenameControllerPaneTitle:
+    """RenameController sets tmux pane_title directly via TmuxClient."""
 
-    def test_get_returns_empty_when_no_overlay(self) -> None:
-        ctrl = RenameController()
-        assert ctrl.get("work") == ""
-
-    def test_set_and_get(self) -> None:
-        ctrl = RenameController()
-        ctrl.set("work", "My Project")
-        assert ctrl.get("work") == "My Project"
-
-    def test_set_overwrites_existing(self) -> None:
-        ctrl = RenameController()
-        ctrl.set("work", "old")
-        ctrl.set("work", "new")
-        assert ctrl.get("work") == "new"
-
-    def test_delete_removes_overlay(self) -> None:
-        ctrl = RenameController()
-        ctrl.set("work", "label")
-        ctrl.delete("work")
-        assert ctrl.get("work") == ""
-
-    def test_empty_value_treated_as_delete(self) -> None:
-        ctrl = RenameController()
-        ctrl.set("work", "label")
-        ctrl.set("work", "")
-        assert ctrl.get("work") == ""
-
-    def test_start_session_key(self) -> None:
-        ctrl = RenameController()
-        data = make_node_data("session", session_name="myproject")
-        current = ctrl.start(data)
-        assert ctrl.key == "myproject"
-        assert current == ""
-
-    def test_start_window_key(self) -> None:
-        ctrl = RenameController()
-        data = make_node_data("window", session_name="myproject", window_index=2)
-        current = ctrl.start(data)
-        assert ctrl.key == "myproject.2"
-        assert current == ""
-
-    def test_start_pane_key(self) -> None:
-        ctrl = RenameController()
+    def test_start_returns_pane_title(self) -> None:
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        ctrl = RenameController(client)
         data = make_node_data("pane", session_name="myproject", window_index=2, pane_index=1)
+        data[3].pane_title = "existing-title"
         current = ctrl.start(data)
         assert ctrl.key == "myproject.2.1"
-        assert current == ""
-
-    def test_start_returns_existing_overlay(self) -> None:
-        ctrl = RenameController()
-        ctrl.set("myproject", "Existing")
-        data = make_node_data("session", session_name="myproject")
-        current = ctrl.start(data)
-        assert current == "Existing"
+        assert ctrl._pane_id == "%0"
+        assert current == "existing-title"
 
     def test_start_none_returns_none(self) -> None:
-        ctrl = RenameController()
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        ctrl = RenameController(client)
         assert ctrl.start(None) is None
 
-    def test_finish_sets_overlay(self) -> None:
-        ctrl = RenameController()
-        ctrl.start(make_node_data("session", session_name="work"))
-        result = ctrl.finish("New Label")
-        assert result == "work"
-        assert ctrl.get("work") == "New Label"
+    def test_finish_calls_set_pane_title(self) -> None:
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.set_pane_title.return_value = True
+        ctrl = RenameController(client)
+        ctrl.start(make_node_data("pane", session_name="work"))
+        result = ctrl.finish("New Title")
+        assert result == "work.0.0"
+        client.set_pane_title.assert_called_once_with("%0", "New Title")
 
-    def test_finish_empty_deletes_overlay(self) -> None:
-        ctrl = RenameController()
-        ctrl.set("work", "Existing")
-        ctrl.start(make_node_data("session", session_name="work"))
+    def test_finish_empty_calls_set_pane_title(self) -> None:
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        client.set_pane_title.return_value = True
+        ctrl = RenameController(client)
+        ctrl.start(make_node_data("pane", session_name="work"))
         result = ctrl.finish("")
-        assert result == "work"
-        assert ctrl.get("work") == ""
+        assert result == "work.0.0"
+        client.set_pane_title.assert_called_once_with("%0", "")
 
     def test_finish_without_start_is_noop(self) -> None:
-        ctrl = RenameController()
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        ctrl = RenameController(client)
         assert ctrl.finish("x") is None
+        client.set_pane_title.assert_not_called()
 
     def test_cancel_clears_key_without_saving(self) -> None:
-        ctrl = RenameController()
-        ctrl.start(make_node_data("session", session_name="work"))
+        from unittest.mock import MagicMock
+        client = MagicMock()
+        ctrl = RenameController(client)
+        ctrl.start(make_node_data("pane", session_name="work"))
         ctrl.cancel()
         assert ctrl.key is None
-        assert ctrl.get("work") == ""
+        assert ctrl._pane_id is None
 
-    def test_apply_to_tree(self) -> None:
-        """apply() should set custom_label on the tree from overlays."""
+    def test_apply_is_noop(self) -> None:
+        from unittest.mock import MagicMock
         from muxpilot.models import TmuxTree
         from conftest import make_session, make_window, make_pane
 
@@ -136,35 +105,10 @@ class TestRenameControllerOverlay:
             ])
         ])
 
-        ctrl = RenameController()
-        ctrl.set("work", "Project A")
-        ctrl.set("work.0", "Editor Window")
-        ctrl.set("work.0.0", "Main Pane")
-
-        ctrl.apply(tree)
-
-        assert tree.sessions[0].custom_label == "Project A"
-        assert tree.sessions[0].windows[0].custom_label == "Editor Window"
-        assert tree.sessions[0].windows[0].panes[0].custom_label == "Main Pane"
-
-    def test_apply_skips_missing_overlays(self) -> None:
-        from muxpilot.models import TmuxTree
-        from conftest import make_session, make_window, make_pane
-
-        tree = TmuxTree(sessions=[
-            make_session(session_name="work", windows=[
-                make_window(window_index=0, panes=[make_pane(pane_index=0)])
-            ])
-        ])
-
-        ctrl = RenameController()
+        client = MagicMock()
+        ctrl = RenameController(client)
         ctrl.apply(tree)
 
         assert tree.sessions[0].custom_label == ""
-
-    def test_overlay_does_not_persist_across_instances(self) -> None:
-        ctrl1 = RenameController()
-        ctrl1.set("work", "temp")
-
-        ctrl2 = RenameController()
-        assert ctrl2.get("work") == ""
+        assert tree.sessions[0].windows[0].custom_label == ""
+        assert tree.sessions[0].windows[0].panes[0].custom_label == ""

--- a/tests/test_tmux_client.py
+++ b/tests/test_tmux_client.py
@@ -15,7 +15,7 @@ from muxpilot.tmux_client import (
 )
 
 
-def _mock_pane(pane_id="%0", cmd="bash", path="/home/user", active="1", w="80", h="24", pid="1234"):
+def _mock_pane(pane_id="%0", cmd="bash", path="/home/user", active="1", w="80", h="24", pid="1234", title=""):
     p = MagicMock()
     p.pane_id = pane_id
     p.pane_index = "0"
@@ -25,6 +25,7 @@ def _mock_pane(pane_id="%0", cmd="bash", path="/home/user", active="1", w="80", 
     p.pane_width = w
     p.pane_height = h
     p.pane_pid = pid
+    p.pane_title = title
     return p
 
 
@@ -228,3 +229,56 @@ class TestGetFullCommand:
         with patch("muxpilot.tmux_client.psutil.Process", side_effect=psutil.AccessDenied(1234)):
             result = c._get_full_command(p)
         assert result == "bash"
+
+
+class TestPaneTitleAndGit:
+    def test_get_tree_reads_pane_title(self):
+        p = _mock_pane(pane_id="%1", title="agent-1")
+        w = _mock_window(wid="@1", panes=[p])
+        s = _mock_session(sid="$1", windows=[w])
+        c = _client_with([s])
+        with patch.object(c, "_get_git_info", return_value={"repo_name": "", "branch": ""}):
+            tree = c.get_tree()
+        pane = tree.sessions[0].windows[0].panes[0]
+        assert pane.pane_title == "agent-1"
+
+    def test_get_tree_populates_git_info(self):
+        p = _mock_pane(pane_id="%1", path="/home/user/proj")
+        w = _mock_window(wid="@1", panes=[p])
+        s = _mock_session(sid="$1", windows=[w])
+        c = _client_with([s])
+        with patch.object(c, "_get_git_info", return_value={"repo_name": "proj", "branch": "main"}):
+            tree = c.get_tree()
+        pane = tree.sessions[0].windows[0].panes[0]
+        assert pane.repo_name == "proj"
+        assert pane.branch == "main"
+
+    def test_get_git_info_success(self):
+        c = _client_with([])
+        with patch("muxpilot.tmux_client.subprocess.run") as mock_run:
+            mock_run.side_effect = [
+                MagicMock(stdout="/home/user/proj\n", returncode=0),
+                MagicMock(stdout="feature/x\n", returncode=0),
+            ]
+            result = c._get_git_info("/home/user/proj")
+        assert result == {"repo_name": "proj", "branch": "feature/x"}
+
+    def test_get_git_info_not_a_repo(self):
+        import subprocess
+        c = _client_with([])
+        with patch("muxpilot.tmux_client.subprocess.run", side_effect=subprocess.CalledProcessError(128, "git")):
+            result = c._get_git_info("/tmp")
+        assert result == {"repo_name": "", "branch": ""}
+
+    def test_set_pane_title_calls_tmux(self):
+        c = _client_with([])
+        result = c.set_pane_title("%1", "new-title")
+        c.server.cmd.assert_called_once_with("select-pane", "-t", "%1", "-T", "new-title")
+        assert result is True
+
+    def test_set_pane_title_failure(self):
+        import libtmux.exc
+        c = _client_with([])
+        c.server.cmd.side_effect = libtmux.exc.LibTmuxException("fail")
+        result = c.set_pane_title("%1", "new-title")
+        assert result is False

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -263,3 +263,18 @@ class TestPoll:
         _, events = w.poll()
         focus_events = [e for e in events if e.event_type == "focus_changed"]
         assert focus_events == []
+
+    def test_poll_sets_recent_lines_on_activity(self):
+        client = make_mock_client(capture_content=["line1", "line2", "line3"])
+        w = TmuxWatcher(client, preview_lines=2)
+        tree, _ = w.poll()
+        activity = w.activities.get(tree.all_panes()[0].pane_id)
+        assert activity is not None
+        assert activity.recent_lines == ["line2", "line3"]
+
+    def test_poll_sets_idle_seconds_on_pane_info(self):
+        tree = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])])
+        client = make_mock_client(tree=tree, capture_content=["$ "])
+        w = TmuxWatcher(client)
+        tree, _ = w.poll()
+        assert tree.all_panes()[0].idle_seconds == 0.0


### PR DESCRIPTION
## Summary
- Pane detail panel now shows **Title**, **Repository**, **Branch**, **idle time**, and a **5-line recent output preview** — optimized for users running multiple coding agents in parallel.
- `PaneInfo` / `PaneActivity` models extended with `pane_title`, `repo_name`, `branch`, `idle_seconds`, `recent_lines`.
- `TmuxClient` reads `pane_title` from libtmux, runs `git` commands to extract repo/branch info, and adds `set_pane_title()`.
- `TmuxWatcher` stores recent output lines and copies `idle_seconds` to `PaneInfo`.
- **Rename (`n` key)** now sets tmux `pane_title` directly via `TmuxClient.set_pane_title()` instead of in-memory overlays.
- Tree view labels prefer `pane_title` when available.

## Test Plan
- [x] All 185 tests pass
- [x] New tests cover `display_label` priority, git info extraction, `set_pane_title`, watcher preview/idle, and detail panel rendering