### PR TITLE
feat: add pastel color animation for ACTIVE pane icons

### DIFF
--- a/src/muxpilot/models.py
+++ b/src/muxpilot/models.py
@@ -45,10 +45,13 @@ class PaneInfo:
     idle_seconds: float = 0.0
     recent_lines: list[str] = field(default_factory=list)
 
-    @property
-    def display_label(self) -> str:
-        """Label for tree view display."""
-        icon = STATUS_ICONS.get(self.status, "?")
+    def get_display_label(self, icon_override: str | None = None) -> str:
+        """Label for tree view display.
+
+        Args:
+            icon_override: If given, replaces the default status icon markup.
+        """
+        icon = icon_override if icon_override is not None else STATUS_ICONS.get(self.status, "?")
         if self.pane_title:
             return f"{icon} {self.pane_title}"
         if self.custom_label:
@@ -71,6 +74,11 @@ class PaneInfo:
             cmd = self.current_command or self.full_command
 
         return f"{icon} {cmd} — {short_path}"
+
+    @property
+    def display_label(self) -> str:
+        """Label for tree view display."""
+        return self.get_display_label()
 
 
 @dataclass

--- a/src/muxpilot/widgets/tree_view.py
+++ b/src/muxpilot/widgets/tree_view.py
@@ -9,7 +9,12 @@ from textual.message import Message
 from textual.widgets import Tree
 from textual.widgets._tree import TreeNode
 
-from muxpilot.models import PaneInfo, PaneStatus, SessionInfo, TmuxTree, WindowInfo
+from muxpilot.models import PaneInfo, PaneStatus, SessionInfo, STATUS_ICONS, TmuxTree, WindowInfo
+
+# Pastel colors for the ACTIVE icon animation (no red)
+_ANIMATION_COLORS = [
+    "#FFD4A3", "#FFFFB3", "#B3FFB3", "#B3D9FF", "#D9B3FF",
+]
 
 
 class TmuxTreeView(Tree[Text]):
@@ -50,6 +55,11 @@ class TmuxTreeView(Tree[Text]):
         self._expanded_paths: set[str] = set()
         self._selected_path: str | None = None
         self._has_populated: bool = False
+        self._animation_frame: int = 0
+
+    def on_mount(self) -> None:
+        """Start the ACTIVE icon animation interval."""
+        self.set_interval(0.3, self._animate_active_icons)
 
     def get_cursor_node_data(self) -> tuple[str, SessionInfo | None, WindowInfo | None, PaneInfo | None] | None:
         """Return the data tuple for the currently cursor-selected node, or None."""
@@ -195,11 +205,7 @@ class TmuxTreeView(Tree[Text]):
                     self._node_data[window_node.id] = ("window", session, window, None)
 
                     for pane in panes:
-                        label_text = Text.from_markup(pane.display_label)
-                        if pane.is_active:
-                            label_text.stylize("bold")
-                        else:
-                            label_text.stylize("dim")
+                        label_text = self._build_pane_label(pane)
 
                         pane_node = window_node.add_leaf(label_text)
                         self._node_data[pane_node.id] = ("pane", session, window, pane)
@@ -212,6 +218,41 @@ class TmuxTreeView(Tree[Text]):
             self._restore_state()
 
         self._has_populated = True
+
+    def _animate_active_icons(self) -> None:
+        """Cycle the color of ACTIVE pane icons."""
+        self._animation_frame += 1
+        color = _ANIMATION_COLORS[self._animation_frame % len(_ANIMATION_COLORS)]
+        animated_icon = f"[{color}]A[/{color}]"
+
+        for node_id, data in self._node_data.items():
+            node_type, session, window, pane = data
+            if node_type != "pane" or pane is None or pane.status != PaneStatus.ACTIVE:
+                continue
+            # Find the node by traversing — node_id is the TreeNode.id
+            for node in self._walk_nodes():
+                if node.id == node_id:
+                    label = self._build_pane_label(pane, animated_icon)
+                    node.set_label(label)
+                    break
+
+    def _walk_nodes(self):
+        """Yield all nodes in the tree (breadth-first)."""
+        queue = [self.root]
+        while queue:
+            node = queue.pop(0)
+            yield node
+            queue.extend(node.children)
+
+    def _build_pane_label(self, pane: PaneInfo, icon: str | None = None) -> Text:
+        """Build a Rich Text label for a pane, optionally overriding the icon."""
+        markup = pane.get_display_label(icon_override=icon)
+        label_text = Text.from_markup(markup)
+        if pane.is_active:
+            label_text.stylize("bold")
+        else:
+            label_text.stylize("dim")
+        return label_text
 
     def on_tree_node_highlighted(self, event: Tree.NodeHighlighted[Text]) -> None:
         """When a node is highlighted, emit NodeInfo for the detail panel."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -152,6 +152,18 @@ class TestPaneInfoDisplayLabel:
         assert "python" in pane.display_label
         assert "user/proj" in pane.display_label
 
+    def test_get_display_label_with_icon_override(self) -> None:
+        """icon_override should replace the default status icon."""
+        pane = make_pane(
+            status=PaneStatus.ACTIVE,
+            current_command="vim",
+            current_path="/tmp/work",
+        )
+        label = pane.get_display_label(icon_override="[bold cyan]X[/bold cyan]")
+        assert label.startswith("[bold cyan]X[/bold cyan]")
+        assert "vim" in label
+        assert "work" in label
+
 
 # ============================================================================
 # WindowInfo.display_label

--- a/tests/test_tree_view.py
+++ b/tests/test_tree_view.py
@@ -59,3 +59,22 @@ def test_error_pane_icon_is_red():
         f"ERROR pane icon should be red, got spans: {label.spans}"
 
 
+def test_active_pane_label_animated():
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[
+            make_pane(pane_id="%0", status=PaneStatus.ACTIVE, is_active=True),
+        ])])
+    ])
+    tw = TmuxTreeView()
+    tw.populate(tree)
+    pane_node = tw.root.children[0].children[0].children[0]
+    initial_label = pane_node.label
+
+    tw._animation_frame = 0
+    tw._animate_active_icons()
+
+    assert tw._animation_frame == 1
+    new_label = pane_node.label
+    assert initial_label != new_label
+
+


### PR DESCRIPTION
## Summary
- ACTIVE ステータスのペインアイコン「A」に、パステルカラーの回転アニメーションを追加
- 0.3秒間隔で色が変化（パステルオレンジ→イエロー→グリーン→ブルー→パープル）
- 赤は除外し、bold スタイルも外して薄く表示

## Changes
- `src/muxpilot/models.py`: `PaneInfo.get_display_label()` を追加（アイコンのオーバーライド対応）
- `src/muxpilot/widgets/tree_view.py`: アニメーションタイマーとカラーサイクルロジックを追加
- `tests/test_models.py` / `tests/test_tree_view.py`: 新機能のテストを追加

## Test Plan
- [x] `uv run pytest tests/ -v` → 199 tests passed