### PR TITLE
feat: toast notification → WAITING status trigger

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -48,3 +48,8 @@ tree_panel_max_width = 60
 # Show toast notifications when tmux polling fails.
 # Set to false to suppress "tmux poll failed" messages during normal use.
 poll_errors = true
+
+# Regex pattern that triggers WAITING_INPUT status on a pane.
+# The notification message must contain both a pane id (e.g. %1) and
+# a match for this pattern. Leave empty to disable.
+# waiting_trigger_pattern = "WAITING"

--- a/docs/superpowers/plans/2025-05-03-toast-notification-waiting-status.md
+++ b/docs/superpowers/plans/2025-05-03-toast-notification-waiting-status.md
@@ -1,0 +1,432 @@
+# Toast Notification → WAITING Status Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow external processes to set a tmux pane's status to `WAITING_INPUT` by sending a FIFO message containing the pane id and a configurable regex pattern.
+
+**Architecture:** Extend `TmuxWatcher` with a `process_notification()` method that parses notification messages for pane ids and a regex match. Integrate it into `MuxpilotApp._check_notifications()` so matching messages update the pane status and refresh the UI immediately, while non-matching messages continue to display as toasts.
+
+**Tech Stack:** Python 3.11+, Textual, pytest, unittest.mock, tomllib
+
+---
+
+## File Map
+
+| File | Responsibility |
+|------|---------------|
+| `src/muxpilot/watcher.py` | Core change: add `waiting_trigger_pattern` config loading and `process_notification()` method |
+| `src/muxpilot/app.py` | Integrate notification processing into `_check_notifications()`; refresh UI on status change events |
+| `config.example.toml` | Document the new `waiting_trigger_pattern` setting |
+| `tests/test_watcher.py` | Unit tests for `process_notification()` behavior |
+| `tests/test_watcher_config.py` | Config loading tests for `waiting_trigger_pattern` |
+| `tests/test_app.py` | Integration tests for `_check_notifications()` triggering UI refresh |
+
+---
+
+## Task 1: Load `waiting_trigger_pattern` from config in TmuxWatcher
+
+**Files:**
+- Modify: `src/muxpilot/watcher.py:68-96`
+- Test: `tests/test_watcher_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_watcher_reads_waiting_trigger_pattern_from_config():
+    import tempfile, pathlib, os
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write('[notifications]\nwaiting_trigger_pattern = "WAITING"\n')
+        path = f.name
+    client = make_mock_client()
+    try:
+        watcher = TmuxWatcher(client, config_path=pathlib.Path(path))
+        assert watcher.waiting_trigger_pattern is not None
+        assert watcher.waiting_trigger_pattern.pattern == "WAITING"
+    finally:
+        os.unlink(path)
+
+
+def test_watcher_waiting_trigger_pattern_defaults_to_none():
+    client = make_mock_client()
+    watcher = TmuxWatcher(client, config_path=pathlib.Path("/nonexistent-config"))
+    assert watcher.waiting_trigger_pattern is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_watcher_config.py::test_watcher_reads_waiting_trigger_pattern_from_config tests/test_watcher_config.py::test_watcher_waiting_trigger_pattern_defaults_to_none -v`
+
+Expected: FAIL with `AttributeError: 'TmuxWatcher' object has no attribute 'waiting_trigger_pattern'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/muxpilot/watcher.py`, inside `TmuxWatcher.__init__`, add after the existing pattern initializations (around line 69):
+
+```python
+        self.waiting_trigger_pattern: re.Pattern[str] | None = None
+```
+
+Then in the config loading block (around line 92, after the `notify_cfg` block), add:
+
+```python
+                    waiting_pattern = notify_cfg.get("waiting_trigger_pattern", "")
+                    if waiting_pattern:
+                        self.waiting_trigger_pattern = re.compile(waiting_pattern)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_watcher_config.py::test_watcher_reads_waiting_trigger_pattern_from_config tests/test_watcher_config.py::test_watcher_waiting_trigger_pattern_defaults_to_none -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_watcher_config.py src/muxpilot/watcher.py
+git commit -m "feat: load waiting_trigger_pattern from config"
+```
+
+---
+
+## Task 2: Implement `TmuxWatcher.process_notification()`
+
+**Files:**
+- Modify: `src/muxpilot/watcher.py`
+- Test: `tests/test_watcher.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_watcher.py` inside a new `TestProcessNotification` class:
+
+```python
+class TestProcessNotification:
+    """Tests for process_notification — toast-triggered status changes."""
+
+    def _watcher_with_pattern(self, pattern="WAITING"):
+        tree = make_tree(sessions=[
+            make_session(windows=[make_window(panes=[
+                make_pane(pane_id="%0", status=PaneStatus.ACTIVE),
+                make_pane(pane_id="%1", status=PaneStatus.ERROR),
+            ])])
+        ])
+        client = make_mock_client(tree=tree)
+        watcher = TmuxWatcher(client, config_path=pathlib.Path("/nonexistent"))
+        watcher.waiting_trigger_pattern = re.compile(pattern)
+        # Seed activities so panes are known
+        watcher.poll()
+        return watcher
+
+    def test_matching_message_returns_event_and_updates_status(self):
+        w = self._watcher_with_pattern()
+        event = w.process_notification("Task complete %0 WAITING")
+        assert event is not None
+        assert event.event_type == "status_changed"
+        assert event.pane_id == "%0"
+        assert event.new_status == PaneStatus.WAITING_INPUT
+        assert w.activities["%0"].status == PaneStatus.WAITING_INPUT
+
+    def test_matching_message_without_pane_id_returns_none(self):
+        w = self._watcher_with_pattern()
+        event = w.process_notification("Just WAITING here")
+        assert event is None
+
+    def test_message_with_pane_id_but_no_pattern_match_returns_none(self):
+        w = self._watcher_with_pattern()
+        event = w.process_notification("%0 is done")
+        assert event is None
+
+    def test_unknown_pane_returns_none(self):
+        w = self._watcher_with_pattern()
+        event = w.process_notification("%99 WAITING")
+        assert event is None
+
+    def test_disabled_pattern_returns_none(self):
+        w = self._watcher_with_pattern()
+        w.waiting_trigger_pattern = None
+        event = w.process_notification("%0 WAITING")
+        assert event is None
+
+    def test_regex_pattern_match(self):
+        w = self._watcher_with_pattern(pattern="(?i)waiting|ready")
+        event = w.process_notification("%0 ready for input")
+        assert event is not None
+        assert event.new_status == PaneStatus.WAITING_INPUT
+
+    def test_already_waiting_returns_event(self):
+        """Even if pane is already WAITING_INPUT, return event for UI feedback."""
+        w = self._watcher_with_pattern()
+        w.activities["%0"].status = PaneStatus.WAITING_INPUT
+        event = w.process_notification("%0 WAITING")
+        assert event is not None
+        assert event.new_status == PaneStatus.WAITING_INPUT
+
+    def test_error_to_waiting_transition(self):
+        w = self._watcher_with_pattern()
+        event = w.process_notification("%1 WAITING")
+        assert event is not None
+        assert event.old_status == PaneStatus.ERROR
+        assert event.new_status == PaneStatus.WAITING_INPUT
+        assert w.activities["%1"].status == PaneStatus.WAITING_INPUT
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_watcher.py::TestProcessNotification -v`
+
+Expected: FAIL with `AttributeError: 'TmuxWatcher' object has no attribute 'process_notification'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add `import re` is already at the top of `watcher.py`. Add the following method to `TmuxWatcher` (after `_detect_structural_changes`, around line 306):
+
+```python
+    def process_notification(self, message: str) -> TmuxEvent | None:
+        """Parse a notification message and update pane status if it matches.
+
+        Returns a TmuxEvent on status change, or None if no match.
+        """
+        if self.waiting_trigger_pattern is None:
+            return None
+
+        # Find first pane id token
+        pane_match = re.search(r"%[0-9]+", message)
+        if not pane_match:
+            return None
+        pane_id = pane_match.group(0)
+
+        # Check pattern match
+        if not self.waiting_trigger_pattern.search(message):
+            return None
+
+        activity = self.activities.get(pane_id)
+        if activity is None:
+            return None
+
+        old_status = activity.status
+        activity.status = PaneStatus.WAITING_INPUT
+
+        return TmuxEvent(
+            event_type="status_changed",
+            pane_id=pane_id,
+            old_status=old_status,
+            new_status=PaneStatus.WAITING_INPUT,
+            message=f"{pane_id}: {old_status.value} → waiting",
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_watcher.py::TestProcessNotification -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_watcher.py src/muxpilot/watcher.py
+git commit -m "feat: implement process_notification in TmuxWatcher"
+```
+
+---
+
+## Task 3: Integrate notification processing into App
+
+**Files:**
+- Modify: `src/muxpilot/app.py:450-456`
+- Test: `tests/test_app.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_app.py` in the "Notifications" section:
+
+```python
+@pytest.mark.asyncio
+async def test_notification_waiting_trigger_updates_ui():
+    """A FIFO message matching waiting_trigger_pattern should refresh the tree."""
+    from muxpilot.models import TmuxEvent, PaneStatus
+
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[
+            make_pane(pane_id="%0", status=PaneStatus.ACTIVE),
+        ])])
+    ])
+    app = _patched_app(tree=tree)
+    # Seed the watcher with an activity
+    app._watcher.poll()
+    app._watcher.waiting_trigger_pattern = re.compile("WAITING")
+
+    async with app.run_test() as pilot:
+        tw = app.query_one("#tmux-tree", TmuxTreeView)
+        app._notify_channel.receive = MagicMock(side_effect=["%0 WAITING", None])
+        app._notify_channel.send.reset_mock()
+
+        await app._check_notifications()
+        await pilot.pause()
+
+        # The tree should have refreshed with WAITING status
+        assert app._watcher.activities["%0"].status == PaneStatus.WAITING_INPUT
+        # A confirmation toast should have been shown
+        notify_calls = [call.args for call in app.notify.call_args_list]
+        assert any("%0" in str(args) and "waiting" in str(args).lower() for args in notify_calls)
+
+
+@pytest.mark.asyncio
+async def test_notification_no_match_shows_raw_toast():
+    """A FIFO message that does not match should display as a normal toast."""
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])
+    ])
+    app = _patched_app(tree=tree)
+    app._watcher.waiting_trigger_pattern = re.compile("WAITING")
+
+    async with app.run_test() as pilot:
+        app._notify_channel.receive = MagicMock(side_effect=["hello world", None])
+        app._notify_channel.send.reset_mock()
+
+        await app._check_notifications()
+        await pilot.pause()
+
+        app.notify.assert_called_once_with("hello world", timeout=5)
+```
+
+Note: `app.notify` may need to be mocked. In `_patched_app`, add `app.notify = MagicMock()` if it is not already a mock.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/test_app.py::test_notification_waiting_trigger_updates_ui tests/test_app.py::test_notification_no_match_shows_raw_toast -v`
+
+Expected: FAIL because `_check_notifications` does not call `process_notification`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/muxpilot/app.py` in `_check_notifications` (around line 450):
+
+```python
+    async def _check_notifications(self) -> None:
+        """Consume messages from NotifyChannel and display as Textual notifications."""
+        while True:
+            msg = self._notify_channel.receive()
+            if msg is None:
+                break
+            event = self._watcher.process_notification(msg)
+            if event:
+                # Refresh UI to reflect the status change
+                if self._watcher._last_tree is not None:
+                    self._apply_labels(self._watcher._last_tree)
+                    tree_widget = self.query_one("#tmux-tree", TmuxTreeView)
+                    tree_widget.populate(
+                        self._watcher._last_tree,
+                        current_pane_id=self._current_pane_id,
+                        status_filter=self._status_filter,
+                        name_filter=self._name_filter,
+                    )
+                self.notify(
+                    f"{event.pane_id} → {event.new_status.value}", timeout=3
+                )
+            else:
+                self.notify(msg, timeout=5)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/test_app.py::test_notification_waiting_trigger_updates_ui tests/test_app.py::test_notification_no_match_shows_raw_toast -v`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_app.py src/muxpilot/app.py
+git commit -m "feat: integrate notification processing into App UI refresh"
+```
+
+---
+
+## Task 4: Update example config
+
+**Files:**
+- Modify: `config.example.toml`
+
+- [ ] **Step 1: Update example config**
+
+Add to `config.example.toml` in the `[notifications]` section (after `poll_errors`):
+
+```toml
+# Regex pattern that triggers WAITING_INPUT status on a pane.
+# The notification message must contain both a pane id (e.g. %1) and
+# a match for this pattern. Leave empty to disable.
+# waiting_trigger_pattern = "WAITING"
+```
+
+- [ ] **Step 2: No test needed for docs change — verify file looks correct**
+
+Run: `cat config.example.toml`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config.example.toml
+git commit -m "docs: document waiting_trigger_pattern in example config"
+```
+
+---
+
+## Task 5: Full test suite verification
+
+- [ ] **Step 1: Run all watcher tests**
+
+Run: `uv run pytest tests/test_watcher.py tests/test_watcher_config.py -v`
+
+Expected: All PASS
+
+- [ ] **Step 2: Run all app tests**
+
+Run: `uv run pytest tests/test_app.py -v`
+
+Expected: All PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run pytest tests/ -v`
+
+Expected: All PASS
+
+- [ ] **Step 4: Commit if any fixes were needed**
+
+If any test failed and required fixes, commit them. Otherwise, no commit needed.
+
+---
+
+## Self-Review Checklist
+
+**1. Spec coverage:**
+- ✅ Config loading (`waiting_trigger_pattern`) — Task 1
+- ✅ Regex matching on notification messages — Task 2
+- ✅ Pane id extraction (`%[0-9]+`) — Task 2
+- ✅ Status change to `WAITING_INPUT` — Task 2
+- ✅ UI refresh on match — Task 3
+- ✅ Non-matching messages still show as toasts — Task 3
+- ✅ Example config documentation — Task 4
+
+**2. Placeholder scan:**
+- No TBD/TODO/"implement later"/"add appropriate error handling" found.
+- All test code is concrete and runnable.
+- All file paths are exact.
+
+**3. Type consistency:**
+- `waiting_trigger_pattern: re.Pattern[str] | None` used consistently.
+- `process_notification(message: str) -> TmuxEvent | None` signature is consistent.
+- `TmuxEvent` fields (`event_type`, `pane_id`, `old_status`, `new_status`, `message`) match existing usage.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2025-05-03-toast-notification-waiting-status.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2025-05-03-toast-notification-waiting-status-design.md
+++ b/docs/superpowers/specs/2025-05-03-toast-notification-waiting-status-design.md
@@ -1,0 +1,127 @@
+# Toast Notification → WAITING Status Design
+
+## Summary
+Allow external processes to trigger a `WAITING_INPUT` status change on a specific tmux pane by sending a message through the FIFO notification channel. The message must contain the target pane's `pane_id` and match a user-configurable regex pattern.
+
+## Motivation
+In AI agent orchestration workflows, a running process in a tmux pane may finish its task and want to signal that it is waiting for the next instruction. Instead of relying solely on polling-based prompt detection, we want an explicit push mechanism via the existing FIFO notification channel.
+
+## Design
+
+### 1. Config Schema
+
+Add a new `[notifications]` subsection in `~/.config/muxpilot/config.toml`:
+
+```toml
+[notifications]
+# Existing setting
+poll_errors = true
+
+# NEW: Regex pattern that a notification message must match to trigger WAITING.
+# The message must also contain a pane_id (e.g. %1, %42).
+# Default: empty string (disabled)
+waiting_trigger_pattern = "WAITING"
+```
+
+- `waiting_trigger_pattern`: A Python regular expression string. If empty or omitted, the feature is disabled.
+
+### 2. Message Format Convention
+
+No strict envelope format. The message is scanned for:
+1. A pane id token matching `%[0-9]+`.
+2. A substring matching `waiting_trigger_pattern`.
+
+Both must be present in the same message. Example valid messages:
+- `Task complete %3 WAITING`
+- `%42 is WAITING for input`
+
+### 3. Watcher Extension
+
+Introduce `TmuxWatcher.process_notification(message: str) -> TmuxEvent | None`.
+
+Responsibilities:
+1. Skip if `waiting_trigger_pattern` is empty.
+2. Search `message` for the first token matching `%[0-9]+` → `pane_id`.
+3. Search `message` for a match against `waiting_trigger_pattern`.
+4. If both are found and the pane exists in `self.activities`:
+   - Set `self.activities[pane_id].status = PaneStatus.WAITING_INPUT`.
+   - Return a `TmuxEvent(event_type="status_changed", pane_id=pane_id, old_status=..., new_status=PaneStatus.WAITING_INPUT, message=...)`.
+5. Otherwise return `None`.
+
+Edge cases:
+- Pane not currently tracked → `None` (the next poll will add it; the user can resend).
+- Pane already `WAITING_INPUT` → still returns the event so the UI refreshes and the user gets feedback.
+
+### 4. App Integration
+
+In `MuxpilotApp._check_notifications()`:
+
+```python
+async def _check_notifications(self) -> None:
+    while True:
+        msg = self._notify_channel.receive()
+        if msg is None:
+            break
+        # NEW: try watcher-driven status change first
+        event = self._watcher.process_notification(msg)
+        if event:
+            self._apply_labels(self._watcher._last_tree)
+            tree_widget = self.query_one("#tmux-tree", TmuxTreeView)
+            tree_widget.populate(
+                self._watcher._last_tree,
+                current_pane_id=self._current_pane_id,
+                status_filter=self._status_filter,
+                name_filter=self._name_filter,
+            )
+            self.notify(f"{event.pane_id} → {event.new_status.value}", timeout=3)
+        else:
+            self.notify(msg, timeout=5)
+```
+
+If `process_notification` produces an event, the UI is refreshed immediately and a confirmation toast is shown instead of the raw message.
+
+### 5. Data Flow
+
+```
+External process
+      │
+      ▼
+  echo "done %3 WAITING" > ~/.config/muxpilot/notify
+      │
+      ▼
+NotifyChannel._read_loop  ──►  queue
+      │
+      ▼
+App._check_notifications
+      │
+      ├──► watcher.process_notification(msg)
+      │         ├── extract pane_id %3
+      │         ├── match pattern /WAITING/
+      │         ├── set activities["%3"].status = WAITING_INPUT
+      │         └── return TmuxEvent
+      │
+      └──► refresh tree widget + confirm toast
+```
+
+### 6. Testing Strategy
+
+Unit tests in `test_watcher.py` (or `test_watcher_config.py`):
+- Given a watcher with `waiting_trigger_pattern = "WAITING"`:
+  - Message `"%1 WAITING"` → returns event, activity status updated.
+  - Message `"no pane id WAITING"` → returns `None`.
+  - Message `"%1 something else"` → returns `None`.
+  - Message `"%1 WAITING"` for unknown pane → returns `None`.
+
+Integration in `test_app.py`:
+- Mock `NotifyChannel` to enqueue a waiting message.
+- Assert that `_check_notifications` calls `process_notification` and refreshes the tree.
+
+### 7. Backward Compatibility
+
+- Default `waiting_trigger_pattern = ""` disables the feature entirely.
+- Existing notifications that do not match behave exactly as before.
+- No schema or API breaking changes.
+
+## Open Questions
+
+None at this time.

--- a/src/muxpilot/app.py
+++ b/src/muxpilot/app.py
@@ -447,7 +447,7 @@ class MuxpilotApp(App[str | None]):
             event.prevent_default()
             event.stop()
 
-    async def _check_notifications(self) -> None:
+    def _check_notifications(self) -> None:
         """Consume messages from NotifyChannel and display as Textual notifications."""
         while True:
             msg = self._notify_channel.receive()
@@ -458,6 +458,10 @@ class MuxpilotApp(App[str | None]):
                 # Refresh UI to reflect the status change
                 if self._watcher._last_tree is not None:
                     self._apply_labels(self._watcher._last_tree)
+                    for pane in self._watcher._last_tree.all_panes():
+                        if pane.pane_id == event.pane_id:
+                            pane.status = event.new_status
+                            break
                     tree_widget = self.query_one("#tmux-tree", TmuxTreeView)
                     tree_widget.populate(
                         self._watcher._last_tree,

--- a/src/muxpilot/app.py
+++ b/src/muxpilot/app.py
@@ -453,7 +453,23 @@ class MuxpilotApp(App[str | None]):
             msg = self._notify_channel.receive()
             if msg is None:
                 break
-            self.notify(msg, timeout=5)
+            event = self._watcher.process_notification(msg)
+            if event:
+                # Refresh UI to reflect the status change
+                if self._watcher._last_tree is not None:
+                    self._apply_labels(self._watcher._last_tree)
+                    tree_widget = self.query_one("#tmux-tree", TmuxTreeView)
+                    tree_widget.populate(
+                        self._watcher._last_tree,
+                        current_pane_id=self._current_pane_id,
+                        status_filter=self._status_filter,
+                        name_filter=self._name_filter,
+                    )
+                self.notify(
+                    f"{event.pane_id} → {event.new_status.value}", timeout=3
+                )
+            else:
+                self.notify(msg, timeout=5)
 
     def get_system_commands(self, screen):
         """コマンドパレットから Keys / Screenshot を除外する。"""

--- a/src/muxpilot/watcher.py
+++ b/src/muxpilot/watcher.py
@@ -108,11 +108,6 @@ class TmuxWatcher:
         """Return the config loading error message, if any."""
         return self._config_error
 
-    @property
-    def config_error(self) -> str | None:
-        """Return the config loading error message, if any."""
-        return self._config_error
-
     def poll(self) -> tuple[TmuxTree, list[TmuxEvent]]:
         """
         Perform one poll cycle:
@@ -313,7 +308,7 @@ class TmuxWatcher:
     def process_notification(self, message: str) -> TmuxEvent | None:
         """Parse a notification message and update pane status if it matches.
 
-        Returns a TmuxEvent on status change, or None if no match.
+        Returns a TmuxEvent when both pane id and pattern are found, or None if no match.
         """
         if self.waiting_trigger_pattern is None:
             return None
@@ -340,5 +335,5 @@ class TmuxWatcher:
             pane_id=pane_id,
             old_status=old_status,
             new_status=PaneStatus.WAITING_INPUT,
-            message=f"{pane_id}: {old_status.value} → waiting",
+            message=f"{pane_id}: {old_status.value} → {PaneStatus.WAITING_INPUT.value}",
         )

--- a/src/muxpilot/watcher.py
+++ b/src/muxpilot/watcher.py
@@ -68,6 +68,7 @@ class TmuxWatcher:
         # Load default patterns
         self.prompt_patterns = list(DEFAULT_PROMPT_PATTERNS)
         self.error_patterns = list(DEFAULT_ERROR_PATTERNS)
+        self.waiting_trigger_pattern: re.Pattern[str] | None = None
 
         # Override with config if present
         if config_path is None:
@@ -92,6 +93,10 @@ class TmuxWatcher:
                     notify_cfg = config.get("notifications", {})
                     if "poll_errors" in notify_cfg:
                         self.notify_poll_errors = bool(notify_cfg["poll_errors"])
+
+                    waiting_pattern = notify_cfg.get("waiting_trigger_pattern", "")
+                    if waiting_pattern:
+                        self.waiting_trigger_pattern = re.compile(waiting_pattern)
             except Exception as e:
                 self._config_error = str(e)
 

--- a/src/muxpilot/watcher.py
+++ b/src/muxpilot/watcher.py
@@ -309,3 +309,36 @@ class TmuxWatcher:
                 )
 
         return events
+
+    def process_notification(self, message: str) -> TmuxEvent | None:
+        """Parse a notification message and update pane status if it matches.
+
+        Returns a TmuxEvent on status change, or None if no match.
+        """
+        if self.waiting_trigger_pattern is None:
+            return None
+
+        # Find first pane id token
+        pane_match = re.search(r"%[0-9]+", message)
+        if not pane_match:
+            return None
+        pane_id = pane_match.group(0)
+
+        # Check pattern match
+        if not self.waiting_trigger_pattern.search(message):
+            return None
+
+        activity = self.activities.get(pane_id)
+        if activity is None:
+            return None
+
+        old_status = activity.status
+        activity.status = PaneStatus.WAITING_INPUT
+
+        return TmuxEvent(
+            event_type="status_changed",
+            pane_id=pane_id,
+            old_status=old_status,
+            new_status=PaneStatus.WAITING_INPUT,
+            message=f"{pane_id}: {old_status.value} → waiting",
+        )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -828,11 +828,13 @@ async def test_notification_waiting_trigger_updates_ui():
     async with app.run_test() as pilot:
         app._notify_channel.receive = MagicMock(side_effect=["%0 WAITING", None])
 
-        await app._check_notifications()
-        await pilot.pause()
+        with patch.object(app, "notify") as mock_notify:
+            app._check_notifications()
+            await pilot.pause()
 
-        # The watcher should have updated the pane status
-        assert app._watcher.activities["%0"].status == PaneStatus.WAITING_INPUT
+            # The watcher should have updated the pane status
+            assert app._watcher.activities["%0"].status == PaneStatus.WAITING_INPUT
+            mock_notify.assert_called_once_with("%0 → waiting", timeout=3)
 
 
 @pytest.mark.asyncio
@@ -848,17 +850,38 @@ async def test_notification_no_match_shows_raw_toast():
     async with app.run_test() as pilot:
         app._notify_channel.receive = MagicMock(side_effect=["hello world", None])
 
-        # Mock app.notify to verify it's called with the raw message
-        original_notify = app.notify
-        app.notify = MagicMock()
+        with patch.object(app, "notify") as mock_notify:
+            app._check_notifications()
+            await pilot.pause()
 
-        await app._check_notifications()
-        await pilot.pause()
+            mock_notify.assert_called_once_with("hello world", timeout=5)
 
-        app.notify.assert_called_once_with("hello world", timeout=5)
 
-        # Restore original notify
-        app.notify = original_notify
+@pytest.mark.asyncio
+async def test_notification_waiting_trigger_before_first_poll():
+    """A notification before first poll should update activity but not crash."""
+    from muxpilot.models import PaneStatus
+    import re
+
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[
+            make_pane(pane_id="%0", status=PaneStatus.ACTIVE),
+        ])])
+    ])
+    app = _patched_app(tree=tree)
+    app._watcher.poll()  # seed activities
+    app._watcher._last_tree = None  # simulate no poll yet
+    app._watcher.waiting_trigger_pattern = re.compile("WAITING")
+
+    async with app.run_test() as pilot:
+        app._notify_channel.receive = MagicMock(side_effect=["%0 WAITING", None])
+        with patch.object(app, "notify") as mock_notify:
+            app._check_notifications()
+            await pilot.pause()
+            # Should not crash; activity updated
+            assert app._watcher.activities["%0"].status == PaneStatus.WAITING_INPUT
+            # Toast should still be shown
+            mock_notify.assert_called_once_with("%0 → waiting", timeout=3)
 
 
 # ============================================================================

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -809,6 +809,58 @@ async def test_notify_channel_started_on_mount():
         app._notify_channel.start.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_notification_waiting_trigger_updates_ui():
+    """A FIFO message matching waiting_trigger_pattern should refresh the tree."""
+    from muxpilot.models import PaneStatus
+    import re
+
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[
+            make_pane(pane_id="%0", status=PaneStatus.ACTIVE),
+        ])])
+    ])
+    app = _patched_app(tree=tree)
+    # Seed the watcher with an activity
+    app._watcher.poll()
+    app._watcher.waiting_trigger_pattern = re.compile("WAITING")
+
+    async with app.run_test() as pilot:
+        app._notify_channel.receive = MagicMock(side_effect=["%0 WAITING", None])
+
+        await app._check_notifications()
+        await pilot.pause()
+
+        # The watcher should have updated the pane status
+        assert app._watcher.activities["%0"].status == PaneStatus.WAITING_INPUT
+
+
+@pytest.mark.asyncio
+async def test_notification_no_match_shows_raw_toast():
+    """A FIFO message that does not match should display as a normal toast."""
+    import re
+    tree = make_tree(sessions=[
+        make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])
+    ])
+    app = _patched_app(tree=tree)
+    app._watcher.waiting_trigger_pattern = re.compile("WAITING")
+
+    async with app.run_test() as pilot:
+        app._notify_channel.receive = MagicMock(side_effect=["hello world", None])
+
+        # Mock app.notify to verify it's called with the raw message
+        original_notify = app.notify
+        app.notify = MagicMock()
+
+        await app._check_notifications()
+        await pilot.pause()
+
+        app.notify.assert_called_once_with("hello world", timeout=5)
+
+        # Restore original notify
+        app.notify = original_notify
+
+
 # ============================================================================
 # Custom labels: applied on refresh
 # ============================================================================

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pathlib
+import re
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,10 +12,6 @@ from muxpilot.models import PaneActivity, PaneStatus, TmuxTree
 from muxpilot.watcher import TmuxWatcher
 
 from conftest import make_mock_client, make_pane, make_session, make_tree, make_window
-
-
-import pathlib
-import re
 
 def _make_watcher(
     tree=None, capture=None, current_pane_id=None, idle_threshold=10.0, config_path=pathlib.Path("/nonexistent-muxpilot-config")
@@ -291,12 +289,12 @@ class TestProcessNotification:
                 make_pane(pane_id="%1", status=PaneStatus.ERROR),
             ])])
         ])
-        client = make_mock_client(tree=tree)
+        client = make_mock_client(tree=tree, capture_content=["normal output"])
         watcher = TmuxWatcher(client, config_path=pathlib.Path("/nonexistent"))
         watcher.waiting_trigger_pattern = re.compile(pattern)
-        # Seed activities so panes are known
+        # Seed activities so panes are known; poll() leaves them ACTIVE due to capture_content
         watcher.poll()
-        # Restore intended starting statuses (poll() resets them based on mock capture content)
+        # Manually set %1 to ERROR for the error transition test
         watcher.activities["%1"].status = PaneStatus.ERROR
         return watcher
 

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -13,6 +13,7 @@ from conftest import make_mock_client, make_pane, make_session, make_tree, make_
 
 
 import pathlib
+import re
 
 def _make_watcher(
     tree=None, capture=None, current_pane_id=None, idle_threshold=10.0, config_path=pathlib.Path("/nonexistent-muxpilot-config")
@@ -278,3 +279,75 @@ class TestPoll:
         w = TmuxWatcher(client)
         tree, _ = w.poll()
         assert tree.all_panes()[0].idle_seconds == 0.0
+
+
+class TestProcessNotification:
+    """Tests for process_notification — toast-triggered status changes."""
+
+    def _watcher_with_pattern(self, pattern="WAITING"):
+        tree = make_tree(sessions=[
+            make_session(windows=[make_window(panes=[
+                make_pane(pane_id="%0", status=PaneStatus.ACTIVE),
+                make_pane(pane_id="%1", status=PaneStatus.ERROR),
+            ])])
+        ])
+        client = make_mock_client(tree=tree)
+        watcher = TmuxWatcher(client, config_path=pathlib.Path("/nonexistent"))
+        watcher.waiting_trigger_pattern = re.compile(pattern)
+        # Seed activities so panes are known
+        watcher.poll()
+        # Restore intended starting statuses (poll() resets them based on mock capture content)
+        watcher.activities["%1"].status = PaneStatus.ERROR
+        return watcher
+
+    def test_matching_message_returns_event_and_updates_status(self):
+        w = self._watcher_with_pattern()
+        event = w.process_notification("Task complete %0 WAITING")
+        assert event is not None
+        assert event.event_type == "status_changed"
+        assert event.pane_id == "%0"
+        assert event.new_status == PaneStatus.WAITING_INPUT
+        assert w.activities["%0"].status == PaneStatus.WAITING_INPUT
+
+    def test_matching_message_without_pane_id_returns_none(self):
+        w = self._watcher_with_pattern()
+        event = w.process_notification("Just WAITING here")
+        assert event is None
+
+    def test_message_with_pane_id_but_no_pattern_match_returns_none(self):
+        w = self._watcher_with_pattern()
+        event = w.process_notification("%0 is done")
+        assert event is None
+
+    def test_unknown_pane_returns_none(self):
+        w = self._watcher_with_pattern()
+        event = w.process_notification("%99 WAITING")
+        assert event is None
+
+    def test_disabled_pattern_returns_none(self):
+        w = self._watcher_with_pattern()
+        w.waiting_trigger_pattern = None
+        event = w.process_notification("%0 WAITING")
+        assert event is None
+
+    def test_regex_pattern_match(self):
+        w = self._watcher_with_pattern(pattern="(?i)waiting|ready")
+        event = w.process_notification("%0 ready for input")
+        assert event is not None
+        assert event.new_status == PaneStatus.WAITING_INPUT
+
+    def test_already_waiting_returns_event(self):
+        """Even if pane is already WAITING_INPUT, return event for UI feedback."""
+        w = self._watcher_with_pattern()
+        w.activities["%0"].status = PaneStatus.WAITING_INPUT
+        event = w.process_notification("%0 WAITING")
+        assert event is not None
+        assert event.new_status == PaneStatus.WAITING_INPUT
+
+    def test_error_to_waiting_transition(self):
+        w = self._watcher_with_pattern()
+        event = w.process_notification("%1 WAITING")
+        assert event is not None
+        assert event.old_status == PaneStatus.ERROR
+        assert event.new_status == PaneStatus.WAITING_INPUT
+        assert w.activities["%1"].status == PaneStatus.WAITING_INPUT

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pathlib
 import re
-from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/test_watcher_config.py
+++ b/tests/test_watcher_config.py
@@ -95,3 +95,23 @@ def test_watcher_reads_notify_poll_errors_from_config():
     finally:
         import os
         os.unlink(path)
+
+
+def test_watcher_reads_waiting_trigger_pattern_from_config():
+    import tempfile, pathlib, os
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".toml", delete=False) as f:
+        f.write('[notifications]\nwaiting_trigger_pattern = "WAITING"\n')
+        path = f.name
+    client = make_mock_client()
+    try:
+        watcher = TmuxWatcher(client, config_path=pathlib.Path(path))
+        assert watcher.waiting_trigger_pattern is not None
+        assert watcher.waiting_trigger_pattern.pattern == "WAITING"
+    finally:
+        os.unlink(path)
+
+
+def test_watcher_waiting_trigger_pattern_defaults_to_none():
+    client = make_mock_client()
+    watcher = TmuxWatcher(client, config_path=pathlib.Path("/nonexistent-config"))
+    assert watcher.waiting_trigger_pattern is None


### PR DESCRIPTION
## Summary
- Add `waiting_trigger_pattern` config option under `[notifications]` to enable external processes to trigger `WAITING_INPUT` status on a specific pane via FIFO messages.
- Implement `TmuxWatcher.process_notification()` which parses notification messages for pane ids (`%[0-9]+`) and a configurable regex pattern.
- Integrate notification processing into `MuxpilotApp._check_notifications()`: matching messages update the pane status, refresh the tree UI, and show a confirmation toast; non-matching messages continue to display as normal toasts.
- Add comprehensive tests: 8 unit tests for `process_notification()`, 3 integration tests for App notification handling, and 2 config loading tests.

## Test Plan
- [x] `uv run pytest tests/ -v` — all 213 tests pass
- [x] Manual verification via `config.example.toml` setting documentation