### PR TITLE
refactor: extract TreeParser and remove dead code from tmux_client

### DIFF
--- a/src/muxpilot/tmux_client.py
+++ b/src/muxpilot/tmux_client.py
@@ -7,29 +7,13 @@ import subprocess
 import time
 
 import libtmux
-import psutil
 
-from muxpilot.models import (
-    PaneInfo,
-    SessionInfo,
-    TmuxTree,
-    WindowInfo,
-)
+from muxpilot.models import TmuxTree
+from muxpilot.tree_parser import TreeParser
 
 
 class TmuxClient:
-    """Client for interacting with the tmux server via libtmux."""
-
-    def __init__(self) -> None:
-        self._server: libtmux.Server | None = None
-        self._pane_cache: dict[str, libtmux.Pane] = {}
-
-    @property
-    def server(self) -> libtmux.Server:
-        """Lazily connect to the tmux server."""
-        if self._server is None:
-            self._server = libtmux.Server()
-        return self._server
+    """Client for interacting with the tmux server."""
 
     def is_inside_tmux(self) -> bool:
         """Check if we are running inside a tmux session."""
@@ -62,71 +46,17 @@ class TmuxClient:
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
             return tree
 
-        sessions: dict[str, SessionInfo] = {}
-        windows: dict[str, WindowInfo] = {}
+        tree = TreeParser.parse_list_panes_output(result.stdout, self_pane_id)
+        tree.timestamp = time.time()
 
-        for line in result.stdout.splitlines():
-            if not line:
-                continue
-            parts = line.split("\t")
-            if len(parts) < 16:
-                continue
+        # Attach git metadata (not available from tmux format strings)
+        for session in tree.sessions:
+            for window in session.windows:
+                for pane in window.panes:
+                    git_info = self._get_git_info(pane.current_path)
+                    pane.repo_name = git_info["repo_name"]
+                    pane.branch = git_info["branch"]
 
-            session_name = parts[0]
-            session_id = parts[1]
-            session_attached = _is_attached_str(parts[2])
-
-            window_id = parts[3]
-            window_name = parts[4]
-            window_index = int(parts[5] or 0)
-            window_active = _is_active_str(parts[6])
-
-            pane_id = parts[7]
-            pane_index = int(parts[8] or 0)
-            current_command = parts[9]
-            current_path = parts[10]
-            pane_active = _is_active_str(parts[11])
-            width = int(parts[12] or 0)
-            height = int(parts[13] or 0)
-            pane_title = parts[15]
-
-            if session_id not in sessions:
-                sessions[session_id] = SessionInfo(
-                    session_name=session_name,
-                    session_id=session_id,
-                    is_attached=session_attached,
-                    windows=[],
-                )
-
-            if window_id not in windows:
-                window_info = WindowInfo(
-                    window_id=window_id,
-                    window_name=window_name,
-                    window_index=window_index,
-                    is_active=window_active,
-                    panes=[],
-                )
-                windows[window_id] = window_info
-                sessions[session_id].windows.append(window_info)
-
-            pane_info = PaneInfo(
-                pane_id=pane_id,
-                pane_index=pane_index,
-                current_command=current_command,
-                current_path=current_path,
-                is_active=pane_active,
-                width=width,
-                height=height,
-                is_self=(pane_id == self_pane_id),
-                full_command="",
-                pane_title=pane_title,
-            )
-            git_info = self._get_git_info(pane_info.current_path)
-            pane_info.repo_name = git_info["repo_name"]
-            pane_info.branch = git_info["branch"]
-            windows[window_id].panes.append(pane_info)
-
-        tree.sessions = list(sessions.values())
         return tree
 
     def navigate_to(self, pane_id: str) -> bool:
@@ -137,40 +67,25 @@ class TmuxClient:
         cross-session, cross-window navigation automatically without
         relying on cached libtmux objects that may become stale.
         """
+        server = libtmux.Server()
         try:
-            self.server.cmd("switch-client", "-t", pane_id)
+            server.cmd("switch-client", "-t", pane_id)
             return True
         except libtmux.exc.LibTmuxException:
             return False
 
     def kill_pane(self, pane_id: str) -> bool:
-        """Kill the specified pane."""
-        pane = self._find_pane(pane_id)
-        if pane is None:
-            return False
+        """Kill the specified pane via subprocess."""
         try:
-            pane.kill()
+            subprocess.run(
+                ["tmux", "kill-pane", "-t", pane_id],
+                capture_output=True,
+                check=True,
+                timeout=5.0,
+            )
             return True
-        except libtmux.exc.LibTmuxException:
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
             return False
-
-    def _get_full_command(self, pane: libtmux.Pane) -> str:
-        """Get full command line (with arguments) for a pane using psutil.
-
-        If the pane process is a shell with children, returns the child
-        process cmdline. Falls back to pane_current_command on error.
-        """
-        try:
-            pid = int(pane.pane_pid or 0)
-            if pid == 0:
-                return pane.pane_current_command or ""
-            proc = psutil.Process(pid)
-            children = proc.children()
-            if children:
-                return " ".join(children[0].cmdline())
-            return " ".join(proc.cmdline())
-        except (psutil.NoSuchProcess, psutil.AccessDenied, ValueError, TypeError):
-            return pane.pane_current_command or ""
 
     def capture_pane_content(self, pane_id: str, lines: int = 50) -> list[str]:
         """Capture the last N lines of output from a pane via subprocess."""
@@ -208,64 +123,9 @@ class TmuxClient:
 
     def set_pane_title(self, pane_id: str, title: str) -> bool:
         """Set the tmux pane title."""
+        server = libtmux.Server()
         try:
-            self.server.cmd("select-pane", "-t", pane_id, "-T", title)
+            server.cmd("select-pane", "-t", pane_id, "-T", title)
             return True
         except Exception:
             return False
-
-    def _find_pane(self, pane_id: str) -> libtmux.Pane | None:
-        """Find a pane object by its ID across all sessions.
-
-        Uses a cache populated by previous calls to avoid redundant tmux commands.
-        Falls back to a full server scan if the cache miss.
-        """
-        if pane_id in self._pane_cache:
-            return self._pane_cache[pane_id]
-
-        for session in self.server.sessions:
-            for window in session.windows:
-                for pane in window.panes:
-                    if pane.pane_id == pane_id:
-                        return pane
-        return None
-
-
-def _is_attached(session: libtmux.Session) -> bool:
-    """Check if a session is attached."""
-    try:
-        return int(session.session_attached or 0) > 0
-    except (ValueError, TypeError):
-        return False
-
-
-def _is_active_window(window: libtmux.Window) -> bool:
-    """Check if a window is the active window in its session."""
-    try:
-        return int(window.window_active or 0) > 0
-    except (ValueError, TypeError):
-        return False
-
-
-def _is_active_pane(pane: libtmux.Pane) -> bool:
-    """Check if a pane is the active pane in its window."""
-    try:
-        return int(pane.pane_active or 0) > 0
-    except (ValueError, TypeError):
-        return False
-
-
-def _is_attached_str(value: str) -> bool:
-    """Check if a session is attached from a string value."""
-    try:
-        return int(value) > 0
-    except (ValueError, TypeError):
-        return False
-
-
-def _is_active_str(value: str) -> bool:
-    """Check if a window or pane is active from a string value."""
-    try:
-        return int(value) > 0
-    except (ValueError, TypeError):
-        return False

--- a/src/muxpilot/tree_parser.py
+++ b/src/muxpilot/tree_parser.py
@@ -1,0 +1,98 @@
+"""Parse tmux list-panes TSV output into TmuxTree."""
+
+from __future__ import annotations
+
+from muxpilot.models import PaneInfo, SessionInfo, TmuxTree, WindowInfo
+
+
+class TreeParser:
+    """Parse the tab-separated output of tmux list-panes -F into a TmuxTree."""
+
+    @staticmethod
+    def parse_list_panes_output(stdout: str, self_pane_id: str | None = None) -> TmuxTree:
+        """Parse tmux list-panes output and return a TmuxTree.
+
+        Args:
+            stdout: The raw output from ``tmux list-panes -a -F ...``.
+            self_pane_id: The pane ID of the running application. Matched panes
+                will have ``is_self=True``.
+        """
+        tree = TmuxTree()
+        sessions: dict[str, SessionInfo] = {}
+        windows: dict[str, WindowInfo] = {}
+
+        for line in stdout.splitlines():
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) < 16:
+                continue
+
+            session_name = parts[0]
+            session_id = parts[1]
+            session_attached = _is_attached_str(parts[2])
+
+            window_id = parts[3]
+            window_name = parts[4]
+            window_index = int(parts[5] or 0)
+            window_active = _is_active_str(parts[6])
+
+            pane_id = parts[7]
+            pane_index = int(parts[8] or 0)
+            current_command = parts[9]
+            current_path = parts[10]
+            pane_active = _is_active_str(parts[11])
+            width = int(parts[12] or 0)
+            height = int(parts[13] or 0)
+            pane_title = parts[15]
+
+            if session_id not in sessions:
+                sessions[session_id] = SessionInfo(
+                    session_name=session_name,
+                    session_id=session_id,
+                    is_attached=session_attached,
+                    windows=[],
+                )
+
+            if window_id not in windows:
+                window_info = WindowInfo(
+                    window_id=window_id,
+                    window_name=window_name,
+                    window_index=window_index,
+                    is_active=window_active,
+                    panes=[],
+                )
+                windows[window_id] = window_info
+                sessions[session_id].windows.append(window_info)
+
+            pane_info = PaneInfo(
+                pane_id=pane_id,
+                pane_index=pane_index,
+                current_command=current_command,
+                current_path=current_path,
+                is_active=pane_active,
+                width=width,
+                height=height,
+                is_self=(pane_id == self_pane_id),
+                pane_title=pane_title,
+            )
+            windows[window_id].panes.append(pane_info)
+
+        tree.sessions = list(sessions.values())
+        return tree
+
+
+def _is_attached_str(value: str) -> bool:
+    """Check if a session is attached from a string value."""
+    try:
+        return int(value) > 0
+    except (ValueError, TypeError):
+        return False
+
+
+def _is_active_str(value: str) -> bool:
+    """Check if a window or pane is active from a string value."""
+    try:
+        return int(value) > 0
+    except (ValueError, TypeError):
+        return False

--- a/tests/test_tmux_client.py
+++ b/tests/test_tmux_client.py
@@ -1,4 +1,4 @@
-"""Tests for muxpilot.tmux_client — TmuxClient with mocked libtmux."""
+"""Tests for muxpilot.tmux_client — TmuxClient with mocked libtmux/subprocess."""
 
 from __future__ import annotations
 
@@ -8,56 +8,22 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from muxpilot.tmux_client import (
-    TmuxClient,
-    _is_active_pane,
-    _is_active_str,
-    _is_active_window,
-    _is_attached,
-    _is_attached_str,
-)
+from muxpilot.tmux_client import TmuxClient
 
 
-def _mock_pane(pane_id="%0", cmd="bash", path="/home/user", active="1", w="80", h="24", pid="1234", title=""):
-    p = MagicMock()
-    p.pane_id = pane_id
-    p.pane_index = "0"
-    p.pane_current_command = cmd
-    p.pane_current_path = path
-    p.pane_active = active
-    p.pane_width = w
-    p.pane_height = h
-    p.pane_pid = pid
-    p.pane_title = title
-    return p
+def _list_panes_output(lines: list[str]):
+    class _Result:
+        def __init__(self, stdout: str, stderr: str = "", returncode: int = 0):
+            self.stdout = stdout
+            self.stderr = stderr
+            self.returncode = returncode
 
-
-def _mock_window(wid="@0", name="editor", idx="0", active="1", panes=None):
-    w = MagicMock()
-    w.window_id = wid
-    w.window_name = name
-    w.window_index = idx
-    w.window_active = active
-    w.panes = panes or [_mock_pane()]
-    return w
-
-
-def _mock_session(sname="main", sid="$0", attached="1", windows=None, name=None):
-    s = MagicMock()
-    s.session_name = sname
-    s.session_id = sid
-    s.session_attached = attached
-    s.name = name or sname
-    s.windows = windows or [_mock_window()]
-    return s
-
-
-def _client_with(sessions):
-    c = TmuxClient()
-    mock_server = MagicMock()
-    mock_server.sessions = sessions
-    c._server = mock_server
-    return c
+        def check_returncode(self):
+            if self.returncode != 0:
+                raise subprocess.CalledProcessError(
+                    self.returncode, "tmux", output=self.stdout, stderr=self.stderr
+                )
+    return _Result("\n".join(lines))
 
 
 class TestEnv:
@@ -77,21 +43,6 @@ class TestEnv:
         env = {k: v for k, v in os.environ.items() if k != "TMUX_PANE"}
         with patch.dict(os.environ, env, clear=True):
             assert TmuxClient().get_current_pane_id() is None
-
-
-def _list_panes_output(lines: list[str]):
-    class _Result:
-        def __init__(self, stdout: str, stderr: str = "", returncode: int = 0):
-            self.stdout = stdout
-            self.stderr = stderr
-            self.returncode = returncode
-
-        def check_returncode(self):
-            if self.returncode != 0:
-                raise subprocess.CalledProcessError(
-                    self.returncode, "tmux", output=self.stdout, stderr=self.stderr
-                )
-    return _Result("\n".join(lines))
 
 
 class TestGetTree:
@@ -146,25 +97,42 @@ class TestGetTree:
 
 class TestNavigateTo:
     def test_existing(self):
-        c = _client_with([])
-        assert c.navigate_to("%0") is True
-        c.server.cmd.assert_called_with("switch-client", "-t", "%0")
+        mock_server = MagicMock()
+        with patch("muxpilot.tmux_client.libtmux.Server", return_value=mock_server):
+            c = TmuxClient()
+            assert c.navigate_to("%0") is True
+        mock_server.cmd.assert_called_once_with("switch-client", "-t", "%0")
 
     def test_nonexistent(self):
         import libtmux.exc
-        c = _client_with([])
-        c.server.cmd.side_effect = libtmux.exc.LibTmuxException("not found")
-        assert c.navigate_to("%99") is False
+        mock_server = MagicMock()
+        mock_server.cmd.side_effect = libtmux.exc.LibTmuxException("not found")
+        with patch("muxpilot.tmux_client.libtmux.Server", return_value=mock_server):
+            c = TmuxClient()
+            assert c.navigate_to("%99") is False
+
+
+class TestKillPane:
+    def test_success(self):
+        with patch("muxpilot.tmux_client.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            c = TmuxClient()
+            assert c.kill_pane("%0") is True
+        mock_run.assert_called_once_with(
+            ["tmux", "kill-pane", "-t", "%0"],
+            capture_output=True,
+            check=True,
+            timeout=5.0,
+        )
+
+    def test_failure(self):
+        with patch("muxpilot.tmux_client.subprocess.run", side_effect=subprocess.CalledProcessError(1, "tmux")):
+            c = TmuxClient()
+            assert c.kill_pane("%99") is False
 
 
 class TestCapture:
     def test_returns_list(self):
-        with patch("muxpilot.tmux_client.subprocess.run", return_value=_list_panes_output(["a", "b"])):
-            c = TmuxClient()
-            assert c.capture_pane_content("%0") == ["a", "b"]
-
-    def test_returns_string(self):
-        """tmux capture-pane -p returns stdout as a single string."""
         with patch("muxpilot.tmux_client.subprocess.run", return_value=_list_panes_output(["a", "b"])):
             c = TmuxClient()
             assert c.capture_pane_content("%0") == ["a", "b"]
@@ -191,82 +159,6 @@ class TestCapture:
         )
 
 
-class TestHelpers:
-    def test_attached_true(self):
-        s = MagicMock(); s.session_attached = "1"
-        assert _is_attached(s) is True
-
-    def test_attached_false(self):
-        s = MagicMock(); s.session_attached = "0"
-        assert _is_attached(s) is False
-
-    def test_attached_none(self):
-        s = MagicMock(); s.session_attached = None
-        assert _is_attached(s) is False
-
-    def test_attached_invalid(self):
-        s = MagicMock(); s.session_attached = "abc"
-        assert _is_attached(s) is False
-
-    def test_active_window(self):
-        w = MagicMock(); w.window_active = "1"
-        assert _is_active_window(w) is True
-
-    def test_active_pane(self):
-        p = MagicMock(); p.pane_active = "1"
-        assert _is_active_pane(p) is True
-
-
-class TestGetFullCommand:
-    def test_child_process(self):
-        """When shell has a child process, return child's cmdline."""
-        p = _mock_pane(cmd="bash", pid="1234")
-        c = _client_with([])
-
-        mock_child = MagicMock()
-        mock_child.cmdline.return_value = ["python", "script.py", "--help"]
-        mock_proc = MagicMock()
-        mock_proc.children.return_value = [mock_child]
-        mock_proc.cmdline.return_value = ["bash"]
-
-        with patch("muxpilot.tmux_client.psutil.Process", return_value=mock_proc):
-            result = c._get_full_command(p)
-        assert result == "python script.py --help"
-
-    def test_no_child_process(self):
-        """When no child process, return the shell's own cmdline."""
-        p = _mock_pane(cmd="bash", pid="1234")
-        c = _client_with([])
-
-        mock_proc = MagicMock()
-        mock_proc.children.return_value = []
-        mock_proc.cmdline.return_value = ["bash", "-l"]
-
-        with patch("muxpilot.tmux_client.psutil.Process", return_value=mock_proc):
-            result = c._get_full_command(p)
-        assert result == "bash -l"
-
-    def test_process_not_found(self):
-        """Fallback to pane_current_command when process is gone."""
-        import psutil
-        p = _mock_pane(cmd="bash", pid="1234")
-        c = _client_with([])
-
-        with patch("muxpilot.tmux_client.psutil.Process", side_effect=psutil.NoSuchProcess(1234)):
-            result = c._get_full_command(p)
-        assert result == "bash"
-
-    def test_access_denied(self):
-        """Fallback to pane_current_command on permission error."""
-        import psutil
-        p = _mock_pane(cmd="bash", pid="1234")
-        c = _client_with([])
-
-        with patch("muxpilot.tmux_client.psutil.Process", side_effect=psutil.AccessDenied(1234)):
-            result = c._get_full_command(p)
-        assert result == "bash"
-
-
 class TestPaneTitleAndGit:
     def test_get_tree_reads_pane_title(self):
         line = "s\t$1\t1\t@1\tw\t0\t1\t%1\t0\tbash\t/home/user\t1\t80\t24\t1234\tagent-1"
@@ -288,7 +180,7 @@ class TestPaneTitleAndGit:
         assert pane.branch == "main"
 
     def test_get_git_info_success(self):
-        c = _client_with([])
+        c = TmuxClient()
         with patch("muxpilot.tmux_client.subprocess.run") as mock_run:
             mock_run.side_effect = [
                 MagicMock(stdout="/home/user/proj\n", returncode=0),
@@ -298,21 +190,24 @@ class TestPaneTitleAndGit:
         assert result == {"repo_name": "proj", "branch": "feature/x"}
 
     def test_get_git_info_not_a_repo(self):
-        import subprocess
-        c = _client_with([])
+        c = TmuxClient()
         with patch("muxpilot.tmux_client.subprocess.run", side_effect=subprocess.CalledProcessError(128, "git")):
             result = c._get_git_info("/tmp")
         assert result == {"repo_name": "", "branch": ""}
 
     def test_set_pane_title_calls_tmux(self):
-        c = _client_with([])
-        result = c.set_pane_title("%1", "new-title")
-        c.server.cmd.assert_called_once_with("select-pane", "-t", "%1", "-T", "new-title")
+        mock_server = MagicMock()
+        with patch("muxpilot.tmux_client.libtmux.Server", return_value=mock_server):
+            c = TmuxClient()
+            result = c.set_pane_title("%1", "new-title")
+        mock_server.cmd.assert_called_once_with("select-pane", "-t", "%1", "-T", "new-title")
         assert result is True
 
     def test_set_pane_title_failure(self):
         import libtmux.exc
-        c = _client_with([])
-        c.server.cmd.side_effect = libtmux.exc.LibTmuxException("fail")
-        result = c.set_pane_title("%1", "new-title")
+        mock_server = MagicMock()
+        mock_server.cmd.side_effect = libtmux.exc.LibTmuxException("fail")
+        with patch("muxpilot.tmux_client.libtmux.Server", return_value=mock_server):
+            c = TmuxClient()
+            result = c.set_pane_title("%1", "new-title")
         assert result is False

--- a/tests/test_tree_parser.py
+++ b/tests/test_tree_parser.py
@@ -1,0 +1,91 @@
+"""Tests for muxpilot.tree_parser — TSV parsing of tmux list-panes output."""
+
+from __future__ import annotations
+
+import pytest
+
+from muxpilot.tree_parser import TreeParser
+from muxpilot.models import TmuxTree
+
+
+class TestTreeParser:
+    """Tests for parsing tmux list-panes -F output into TmuxTree."""
+
+    def test_basic_single_pane(self):
+        """Single session/window/pane should parse correctly."""
+        stdout = "dev\t$0\t1\t@0\teditor\t0\t1\t%0\t0\tbash\t/home/user\t1\t80\t24\t1234\tmy-pane"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id=None)
+        assert tree.total_sessions == 1
+        assert tree.total_windows == 1
+        assert tree.total_panes == 1
+        assert tree.sessions[0].session_name == "dev"
+        assert tree.sessions[0].session_id == "$0"
+        assert tree.sessions[0].is_attached is True
+        assert tree.sessions[0].windows[0].window_name == "editor"
+        assert tree.sessions[0].windows[0].panes[0].pane_id == "%0"
+        assert tree.sessions[0].windows[0].panes[0].pane_title == "my-pane"
+
+    def test_multiple_sessions_windows_panes(self):
+        """Multiple sessions, windows, and panes should group correctly."""
+        lines = [
+            "s0\t$0\t1\t@0\tw0\t0\t1\t%0\t0\tbash\t/home/user\t1\t80\t24\t1234\tp0",
+            "s0\t$0\t1\t@0\tw0\t0\t1\t%1\t1\tvim\t/home/user\t0\t80\t24\t1235\tp1",
+            "s0\t$0\t1\t@1\tw1\t1\t0\t%2\t0\tpython\t/home/user\t1\t80\t24\t1236\tp2",
+            "s1\t$1\t0\t@2\tw2\t0\t1\t%3\t0\tzsh\t/home/user\t1\t80\t24\t1237\tp3",
+        ]
+        tree = TreeParser.parse_list_panes_output("\n".join(lines), self_pane_id=None)
+        assert tree.total_sessions == 2
+        assert tree.total_windows == 3
+        assert tree.total_panes == 4
+
+    def test_empty_output(self):
+        """Empty stdout should produce an empty tree."""
+        tree = TreeParser.parse_list_panes_output("", self_pane_id=None)
+        assert tree.total_sessions == 0
+        assert tree.total_windows == 0
+        assert tree.total_panes == 0
+
+    def test_none_values(self):
+        """Tab-only line should not crash and produce zero/empty defaults."""
+        stdout = "\t" * 15
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id=None)
+        assert tree.total_sessions == 1
+        assert tree.total_windows == 1
+        assert tree.total_panes == 1
+        pane = tree.sessions[0].windows[0].panes[0]
+        assert pane.current_command == ""
+        assert pane.current_path == ""
+        assert pane.width == 0
+        assert pane.height == 0
+        assert pane.pane_index == 0
+        assert pane.is_active is False
+
+    def test_self_pane_marking(self):
+        """Pane matching self_pane_id should have is_self=True."""
+        stdout = "dev\t$0\t1\t@0\teditor\t0\t1\t%5\t0\tbash\t/home/user\t1\t80\t24\t1234\t"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id="%5")
+        assert tree.sessions[0].windows[0].panes[0].is_self is True
+
+    def test_non_self_pane(self):
+        """Pane not matching self_pane_id should have is_self=False."""
+        stdout = "dev\t$0\t1\t@0\teditor\t0\t1\t%5\t0\tbash\t/home/user\t1\t80\t24\t1234\t"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id="%99")
+        assert tree.sessions[0].windows[0].panes[0].is_self is False
+
+    def test_skips_short_lines(self):
+        """Lines with fewer than 16 fields should be skipped."""
+        stdout = "dev\t$0\t1\t@0\teditor\t0\t1\t%0\t0\tbash\t/home/user\t1\t80\t24"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id=None)
+        assert tree.total_sessions == 0
+
+    def test_window_active_flag(self):
+        """window_active=0 should produce is_active=False."""
+        stdout = "dev\t$0\t1\t@0\teditor\t0\t0\t%0\t0\tbash\t/home/user\t1\t80\t24\t1234\t"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id=None)
+        assert tree.sessions[0].windows[0].is_active is False
+
+    def test_session_attached_flag(self):
+        """session_attached=0 should produce is_attached=False."""
+        stdout = "dev\t$0\t0\t@0\teditor\t0\t1\t%0\t0\tbash\t/home/user\t1\t80\t24\t1234\t"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id=None)
+        assert tree.sessions[0].is_attached is False


### PR DESCRIPTION
## Summary
- Extract TSV parsing logic from `TmuxClient.get_tree()` into new `TreeParser.parse_list_panes_output()` for testability and single responsibility
- Remove dead libtmux helper functions (`_is_attached`, `_is_active_window`, `_is_active_pane`) that were never called by the subprocess-based parser
- Remove unused `_get_full_command()` and `_pane_cache` (psutil dependency no longer needed by tmux_client)
- Rewrite `kill_pane()` to use subprocess instead of libtmux object caching, reducing libtmux surface area
- Update `test_tmux_client.py`: remove dead-code tests, add `TestKillPane`, mock `libtmux.Server` directly
- Add `test_tree_parser.py` with 9 focused unit tests for the extracted parser

## Test Plan
- [x] `uv run pytest tests/ -v` — 218 passed, 0 failed
- [x] New `TreeParser` tests cover single pane, multiple sessions, empty output, null values, self-pane marking, short-line skipping, and flag parsing