### PR TITLE
refactor: decompose TmuxWatcher into PatternMatcher, StructuralChangeDetector, StatusTracker

### DIFF
--- a/src/muxpilot/pattern_matcher.py
+++ b/src/muxpilot/pattern_matcher.py
@@ -1,0 +1,51 @@
+"""Pattern-based status detection for pane output."""
+
+from __future__ import annotations
+
+import re
+
+from muxpilot.models import PaneStatus
+
+
+class PatternMatcher:
+    """Determines pane status based on output patterns (prompts, errors, idle)."""
+
+    def __init__(
+        self,
+        prompt_patterns: list[re.Pattern[str]],
+        error_patterns: list[re.Pattern[str]],
+        idle_threshold: float,
+    ) -> None:
+        self.prompt_patterns = prompt_patterns
+        self.error_patterns = error_patterns
+        self.idle_threshold = idle_threshold
+
+    def determine_status(
+        self,
+        content: list[str],
+        last_line: str,
+        idle: float,
+        old_status: PaneStatus,
+        content_changed: bool,
+    ) -> PaneStatus:
+        """Determine the pane status based on output patterns.
+
+        Once a pane leaves ACTIVE, it keeps its status until content changes.
+        """
+        if not content_changed and old_status != PaneStatus.ACTIVE:
+            return old_status
+
+        recent_lines = content[-10:] if content else []
+        for line in recent_lines:
+            for pattern in self.error_patterns:
+                if pattern.search(line):
+                    return PaneStatus.ERROR
+
+        for pattern in self.prompt_patterns:
+            if pattern.search(last_line):
+                return PaneStatus.WAITING_INPUT
+
+        if idle >= self.idle_threshold:
+            return PaneStatus.IDLE
+
+        return PaneStatus.ACTIVE

--- a/src/muxpilot/status_tracker.py
+++ b/src/muxpilot/status_tracker.py
@@ -1,0 +1,58 @@
+"""Track pane activity over time (content hashes, idle time, recent lines)."""
+
+from __future__ import annotations
+
+import hashlib
+
+from muxpilot.models import PaneActivity, PaneStatus
+
+
+class StatusTracker:
+    """Tracks pane output changes for status detection."""
+
+    def __init__(self, preview_lines: int = 30) -> None:
+        self.preview_lines = preview_lines
+        self.activities: dict[str, PaneActivity] = {}
+
+    def analyze_pane(
+        self,
+        pane_id: str,
+        content: list[str],
+        old_activity: PaneActivity | None,
+        poll_elapsed: float,
+    ) -> PaneActivity:
+        """Analyze pane content and track idle time."""
+        content_str = "\n".join(content)
+        content_hash = hashlib.md5(content_str.encode()).hexdigest()
+        last_line = content[-1].strip() if content else ""
+        recent_lines = content[-self.preview_lines:] if content else []
+
+        content_changed = not (old_activity and old_activity.last_content_hash == content_hash)
+
+        if old_activity and not content_changed:
+            idle_seconds = old_activity.idle_seconds + poll_elapsed
+        else:
+            idle_seconds = 0.0
+
+        status_override = old_activity.status_override if old_activity else None
+        if content_changed and status_override is not None:
+            status_override = None
+
+        activity = PaneActivity(
+            pane_id=pane_id,
+            last_content_hash=content_hash,
+            last_line=last_line,
+            idle_seconds=idle_seconds,
+            status=old_activity.status if old_activity else PaneStatus.ACTIVE,
+            content_changed=content_changed,
+            recent_lines=recent_lines,
+            status_override=status_override,
+        )
+        self.activities[pane_id] = activity
+        return activity
+
+    def cleanup_removed(self, current_pane_ids: set[str]) -> None:
+        """Remove activities for panes that no longer exist."""
+        for pane_id in list(self.activities.keys()):
+            if pane_id not in current_pane_ids:
+                del self.activities[pane_id]

--- a/src/muxpilot/structural_detector.py
+++ b/src/muxpilot/structural_detector.py
@@ -1,0 +1,69 @@
+"""Detect structural changes between two TmuxTree snapshots."""
+
+from __future__ import annotations
+
+from muxpilot.models import TmuxEvent, TmuxTree
+
+
+class StructuralChangeDetector:
+    """Detects additions/removals of sessions, windows, panes, and focus changes."""
+
+    def detect(self, old_tree: TmuxTree, new_tree: TmuxTree) -> list[TmuxEvent]:
+        """Detect additions/removals of sessions, windows, panes, and focus changes."""
+        events: list[TmuxEvent] = []
+
+        old_pane_ids = {p.pane_id for p in old_tree.all_panes()}
+        new_pane_ids = {p.pane_id for p in new_tree.all_panes()}
+
+        for pane_id in new_pane_ids - old_pane_ids:
+            events.append(
+                TmuxEvent(
+                    event_type="pane_added",
+                    pane_id=pane_id,
+                    message=f"Pane added: {pane_id}",
+                )
+            )
+
+        for pane_id in old_pane_ids - new_pane_ids:
+            events.append(
+                TmuxEvent(
+                    event_type="pane_removed",
+                    pane_id=pane_id,
+                    message=f"Pane removed: {pane_id}",
+                )
+            )
+
+        old_session_names = {s.session_name for s in old_tree.sessions}
+        new_session_names = {s.session_name for s in new_tree.sessions}
+
+        for name in new_session_names - old_session_names:
+            events.append(
+                TmuxEvent(
+                    event_type="session_added",
+                    session_name=name,
+                    message=f"Session added: {name}",
+                )
+            )
+
+        for name in old_session_names - new_session_names:
+            events.append(
+                TmuxEvent(
+                    event_type="session_removed",
+                    session_name=name,
+                    message=f"Session removed: {name}",
+                )
+            )
+
+        old_active = {p.pane_id for p in old_tree.all_panes() if p.is_active}
+        new_active = {p.pane_id for p in new_tree.all_panes() if p.is_active}
+        if old_active != new_active:
+            for pane_id in new_active - old_active:
+                events.append(
+                    TmuxEvent(
+                        event_type="focus_changed",
+                        pane_id=pane_id,
+                        message=f"Focus changed to: {pane_id}",
+                    )
+                )
+
+        return events

--- a/src/muxpilot/tmux_client.py
+++ b/src/muxpilot/tmux_client.py
@@ -7,29 +7,13 @@ import subprocess
 import time
 
 import libtmux
-import psutil
 
-from muxpilot.models import (
-    PaneInfo,
-    SessionInfo,
-    TmuxTree,
-    WindowInfo,
-)
+from muxpilot.models import TmuxTree
+from muxpilot.tree_parser import TreeParser
 
 
 class TmuxClient:
-    """Client for interacting with the tmux server via libtmux."""
-
-    def __init__(self) -> None:
-        self._server: libtmux.Server | None = None
-        self._pane_cache: dict[str, libtmux.Pane] = {}
-
-    @property
-    def server(self) -> libtmux.Server:
-        """Lazily connect to the tmux server."""
-        if self._server is None:
-            self._server = libtmux.Server()
-        return self._server
+    """Client for interacting with the tmux server."""
 
     def is_inside_tmux(self) -> bool:
         """Check if we are running inside a tmux session."""
@@ -62,71 +46,17 @@ class TmuxClient:
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
             return tree
 
-        sessions: dict[str, SessionInfo] = {}
-        windows: dict[str, WindowInfo] = {}
+        tree = TreeParser.parse_list_panes_output(result.stdout, self_pane_id)
+        tree.timestamp = time.time()
 
-        for line in result.stdout.splitlines():
-            if not line:
-                continue
-            parts = line.split("\t")
-            if len(parts) < 16:
-                continue
+        # Attach git metadata (not available from tmux format strings)
+        for session in tree.sessions:
+            for window in session.windows:
+                for pane in window.panes:
+                    git_info = self._get_git_info(pane.current_path)
+                    pane.repo_name = git_info["repo_name"]
+                    pane.branch = git_info["branch"]
 
-            session_name = parts[0]
-            session_id = parts[1]
-            session_attached = _is_attached_str(parts[2])
-
-            window_id = parts[3]
-            window_name = parts[4]
-            window_index = int(parts[5] or 0)
-            window_active = _is_active_str(parts[6])
-
-            pane_id = parts[7]
-            pane_index = int(parts[8] or 0)
-            current_command = parts[9]
-            current_path = parts[10]
-            pane_active = _is_active_str(parts[11])
-            width = int(parts[12] or 0)
-            height = int(parts[13] or 0)
-            pane_title = parts[15]
-
-            if session_id not in sessions:
-                sessions[session_id] = SessionInfo(
-                    session_name=session_name,
-                    session_id=session_id,
-                    is_attached=session_attached,
-                    windows=[],
-                )
-
-            if window_id not in windows:
-                window_info = WindowInfo(
-                    window_id=window_id,
-                    window_name=window_name,
-                    window_index=window_index,
-                    is_active=window_active,
-                    panes=[],
-                )
-                windows[window_id] = window_info
-                sessions[session_id].windows.append(window_info)
-
-            pane_info = PaneInfo(
-                pane_id=pane_id,
-                pane_index=pane_index,
-                current_command=current_command,
-                current_path=current_path,
-                is_active=pane_active,
-                width=width,
-                height=height,
-                is_self=(pane_id == self_pane_id),
-                full_command="",
-                pane_title=pane_title,
-            )
-            git_info = self._get_git_info(pane_info.current_path)
-            pane_info.repo_name = git_info["repo_name"]
-            pane_info.branch = git_info["branch"]
-            windows[window_id].panes.append(pane_info)
-
-        tree.sessions = list(sessions.values())
         return tree
 
     def navigate_to(self, pane_id: str) -> bool:
@@ -137,40 +67,25 @@ class TmuxClient:
         cross-session, cross-window navigation automatically without
         relying on cached libtmux objects that may become stale.
         """
+        server = libtmux.Server()
         try:
-            self.server.cmd("switch-client", "-t", pane_id)
+            server.cmd("switch-client", "-t", pane_id)
             return True
         except libtmux.exc.LibTmuxException:
             return False
 
     def kill_pane(self, pane_id: str) -> bool:
-        """Kill the specified pane."""
-        pane = self._find_pane(pane_id)
-        if pane is None:
-            return False
+        """Kill the specified pane via subprocess."""
         try:
-            pane.kill()
+            subprocess.run(
+                ["tmux", "kill-pane", "-t", pane_id],
+                capture_output=True,
+                check=True,
+                timeout=5.0,
+            )
             return True
-        except libtmux.exc.LibTmuxException:
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
             return False
-
-    def _get_full_command(self, pane: libtmux.Pane) -> str:
-        """Get full command line (with arguments) for a pane using psutil.
-
-        If the pane process is a shell with children, returns the child
-        process cmdline. Falls back to pane_current_command on error.
-        """
-        try:
-            pid = int(pane.pane_pid or 0)
-            if pid == 0:
-                return pane.pane_current_command or ""
-            proc = psutil.Process(pid)
-            children = proc.children()
-            if children:
-                return " ".join(children[0].cmdline())
-            return " ".join(proc.cmdline())
-        except (psutil.NoSuchProcess, psutil.AccessDenied, ValueError, TypeError):
-            return pane.pane_current_command or ""
 
     def capture_pane_content(self, pane_id: str, lines: int = 50) -> list[str]:
         """Capture the last N lines of output from a pane via subprocess."""
@@ -208,64 +123,9 @@ class TmuxClient:
 
     def set_pane_title(self, pane_id: str, title: str) -> bool:
         """Set the tmux pane title."""
+        server = libtmux.Server()
         try:
-            self.server.cmd("select-pane", "-t", pane_id, "-T", title)
+            server.cmd("select-pane", "-t", pane_id, "-T", title)
             return True
         except Exception:
             return False
-
-    def _find_pane(self, pane_id: str) -> libtmux.Pane | None:
-        """Find a pane object by its ID across all sessions.
-
-        Uses a cache populated by previous calls to avoid redundant tmux commands.
-        Falls back to a full server scan if the cache miss.
-        """
-        if pane_id in self._pane_cache:
-            return self._pane_cache[pane_id]
-
-        for session in self.server.sessions:
-            for window in session.windows:
-                for pane in window.panes:
-                    if pane.pane_id == pane_id:
-                        return pane
-        return None
-
-
-def _is_attached(session: libtmux.Session) -> bool:
-    """Check if a session is attached."""
-    try:
-        return int(session.session_attached or 0) > 0
-    except (ValueError, TypeError):
-        return False
-
-
-def _is_active_window(window: libtmux.Window) -> bool:
-    """Check if a window is the active window in its session."""
-    try:
-        return int(window.window_active or 0) > 0
-    except (ValueError, TypeError):
-        return False
-
-
-def _is_active_pane(pane: libtmux.Pane) -> bool:
-    """Check if a pane is the active pane in its window."""
-    try:
-        return int(pane.pane_active or 0) > 0
-    except (ValueError, TypeError):
-        return False
-
-
-def _is_attached_str(value: str) -> bool:
-    """Check if a session is attached from a string value."""
-    try:
-        return int(value) > 0
-    except (ValueError, TypeError):
-        return False
-
-
-def _is_active_str(value: str) -> bool:
-    """Check if a window or pane is active from a string value."""
-    try:
-        return int(value) > 0
-    except (ValueError, TypeError):
-        return False

--- a/src/muxpilot/tree_parser.py
+++ b/src/muxpilot/tree_parser.py
@@ -1,0 +1,98 @@
+"""Parse tmux list-panes TSV output into TmuxTree."""
+
+from __future__ import annotations
+
+from muxpilot.models import PaneInfo, SessionInfo, TmuxTree, WindowInfo
+
+
+class TreeParser:
+    """Parse the tab-separated output of tmux list-panes -F into a TmuxTree."""
+
+    @staticmethod
+    def parse_list_panes_output(stdout: str, self_pane_id: str | None = None) -> TmuxTree:
+        """Parse tmux list-panes output and return a TmuxTree.
+
+        Args:
+            stdout: The raw output from ``tmux list-panes -a -F ...``.
+            self_pane_id: The pane ID of the running application. Matched panes
+                will have ``is_self=True``.
+        """
+        tree = TmuxTree()
+        sessions: dict[str, SessionInfo] = {}
+        windows: dict[str, WindowInfo] = {}
+
+        for line in stdout.splitlines():
+            if not line:
+                continue
+            parts = line.split("\t")
+            if len(parts) < 16:
+                continue
+
+            session_name = parts[0]
+            session_id = parts[1]
+            session_attached = _is_attached_str(parts[2])
+
+            window_id = parts[3]
+            window_name = parts[4]
+            window_index = int(parts[5] or 0)
+            window_active = _is_active_str(parts[6])
+
+            pane_id = parts[7]
+            pane_index = int(parts[8] or 0)
+            current_command = parts[9]
+            current_path = parts[10]
+            pane_active = _is_active_str(parts[11])
+            width = int(parts[12] or 0)
+            height = int(parts[13] or 0)
+            pane_title = parts[15]
+
+            if session_id not in sessions:
+                sessions[session_id] = SessionInfo(
+                    session_name=session_name,
+                    session_id=session_id,
+                    is_attached=session_attached,
+                    windows=[],
+                )
+
+            if window_id not in windows:
+                window_info = WindowInfo(
+                    window_id=window_id,
+                    window_name=window_name,
+                    window_index=window_index,
+                    is_active=window_active,
+                    panes=[],
+                )
+                windows[window_id] = window_info
+                sessions[session_id].windows.append(window_info)
+
+            pane_info = PaneInfo(
+                pane_id=pane_id,
+                pane_index=pane_index,
+                current_command=current_command,
+                current_path=current_path,
+                is_active=pane_active,
+                width=width,
+                height=height,
+                is_self=(pane_id == self_pane_id),
+                pane_title=pane_title,
+            )
+            windows[window_id].panes.append(pane_info)
+
+        tree.sessions = list(sessions.values())
+        return tree
+
+
+def _is_attached_str(value: str) -> bool:
+    """Check if a session is attached from a string value."""
+    try:
+        return int(value) > 0
+    except (ValueError, TypeError):
+        return False
+
+
+def _is_active_str(value: str) -> bool:
+    """Check if a window or pane is active from a string value."""
+    try:
+        return int(value) > 0
+    except (ValueError, TypeError):
+        return False

--- a/src/muxpilot/watcher.py
+++ b/src/muxpilot/watcher.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import os
 import pathlib
 import re
@@ -15,6 +14,9 @@ from muxpilot.models import (
     TmuxEvent,
     TmuxTree,
 )
+from muxpilot.pattern_matcher import PatternMatcher
+from muxpilot.status_tracker import StatusTracker
+from muxpilot.structural_detector import StructuralChangeDetector
 from muxpilot.tmux_client import TmuxClient
 
 
@@ -61,13 +63,12 @@ class TmuxWatcher:
         self.capture_lines = capture_lines
         self.poll_interval = poll_interval
         self.preview_lines = preview_lines
-        self.activities: dict[str, PaneActivity] = {}
         self._config_error: str | None = None
         self.notify_poll_errors: bool = True
 
         # Load default patterns
-        self.prompt_patterns = list(DEFAULT_PROMPT_PATTERNS)
-        self.error_patterns = list(DEFAULT_ERROR_PATTERNS)
+        prompt_patterns = list(DEFAULT_PROMPT_PATTERNS)
+        error_patterns = list(DEFAULT_ERROR_PATTERNS)
         self.waiting_trigger_pattern: re.Pattern[str] | None = None
 
         # Override with config if present
@@ -81,11 +82,11 @@ class TmuxWatcher:
 
                     custom_prompts = watcher_cfg.get("prompt_patterns", [])
                     if custom_prompts:
-                        self.prompt_patterns = [re.compile(p) for p in custom_prompts]
+                        prompt_patterns = [re.compile(p) for p in custom_prompts]
 
                     custom_errors = watcher_cfg.get("error_patterns", [])
                     if custom_errors:
-                        self.error_patterns = [re.compile(p) for p in custom_errors]
+                        error_patterns = [re.compile(p) for p in custom_errors]
 
                     self.idle_threshold = watcher_cfg.get("idle_threshold", self.idle_threshold)
                     self.poll_interval = watcher_cfg.get("poll_interval", self.poll_interval)
@@ -100,6 +101,14 @@ class TmuxWatcher:
             except Exception as e:
                 self._config_error = str(e)
 
+        self._matcher = PatternMatcher(
+            prompt_patterns=prompt_patterns,
+            error_patterns=error_patterns,
+            idle_threshold=self.idle_threshold,
+        )
+        self._tracker = StatusTracker(preview_lines=preview_lines)
+        self._detector = StructuralChangeDetector()
+
         self._last_tree: TmuxTree | None = None
         self._last_poll_time: float | None = None
 
@@ -107,6 +116,26 @@ class TmuxWatcher:
     def config_error(self) -> str | None:
         """Return the config loading error message, if any."""
         return self._config_error
+
+    @property
+    def prompt_patterns(self) -> list[re.Pattern[str]]:
+        """Access prompt patterns (backward compatibility)."""
+        return self._matcher.prompt_patterns
+
+    @property
+    def error_patterns(self) -> list[re.Pattern[str]]:
+        """Access error patterns (backward compatibility)."""
+        return self._matcher.error_patterns
+
+    @property
+    def activities(self) -> dict[str, PaneActivity]:
+        """Access the underlying activity tracker state (for backward compatibility)."""
+        return self._tracker.activities
+
+    @activities.setter
+    def activities(self, value: dict[str, PaneActivity]) -> None:
+        """Replace the activity tracker state (for tests)."""
+        self._tracker.activities = value
 
     def poll(self) -> tuple[TmuxTree, list[TmuxEvent]]:
         """
@@ -121,7 +150,7 @@ class TmuxWatcher:
 
         # Detect structural changes
         if self._last_tree is not None:
-            events.extend(self._detect_structural_changes(self._last_tree, new_tree))
+            events.extend(self._detector.detect(self._last_tree, new_tree))
 
         # Analyze pane outputs and detect status changes
         current_pane_id = self.client.get_current_pane_id()
@@ -135,11 +164,11 @@ class TmuxWatcher:
                 continue
 
             content = self.client.capture_pane_content(pane.pane_id, self.capture_lines)
-            old_activity = self.activities.get(pane.pane_id)
-            new_activity = self._analyze_pane(pane.pane_id, content, old_activity, poll_elapsed)
+            old_activity = self._tracker.activities.get(pane.pane_id)
+            new_activity = self._tracker.analyze_pane(pane.pane_id, content, old_activity, poll_elapsed)
 
             old_status = old_activity.status if old_activity else PaneStatus.ACTIVE
-            new_status = self._determine_status(
+            new_status = self._matcher.determine_status(
                 content,
                 new_activity.last_line,
                 new_activity.idle_seconds,
@@ -166,153 +195,14 @@ class TmuxWatcher:
             pane.status = new_activity.status
             pane.idle_seconds = new_activity.idle_seconds
             pane.recent_lines = new_activity.recent_lines
-            self.activities[pane.pane_id] = new_activity
 
         # Clean up activities for removed panes
         current_pane_ids = {p.pane_id for p in new_tree.all_panes()}
-        for pane_id in list(self.activities.keys()):
-            if pane_id not in current_pane_ids:
-                del self.activities[pane_id]
+        self._tracker.cleanup_removed(current_pane_ids)
 
         self._last_tree = new_tree
         self._last_poll_time = now
         return new_tree, events
-
-    def _analyze_pane(
-        self,
-        pane_id: str,
-        content: list[str],
-        old_activity: PaneActivity | None,
-        poll_elapsed: float,
-    ) -> PaneActivity:
-        """Analyze pane content and track idle time."""
-        content_str = "\n".join(content)
-        content_hash = hashlib.md5(content_str.encode()).hexdigest()
-        last_line = content[-1].strip() if content else ""
-        recent_lines = content[-self.preview_lines:] if content else []
-
-        content_changed = not (old_activity and old_activity.last_content_hash == content_hash)
-
-        if old_activity and not content_changed:
-            idle_seconds = old_activity.idle_seconds + poll_elapsed
-        else:
-            idle_seconds = 0.0
-
-        # Preserve status_override; clear it when content changes
-        status_override = old_activity.status_override if old_activity else None
-        if content_changed and status_override is not None:
-            status_override = None
-
-        return PaneActivity(
-            pane_id=pane_id,
-            last_content_hash=content_hash,
-            last_line=last_line,
-            idle_seconds=idle_seconds,
-            status=old_activity.status if old_activity else PaneStatus.ACTIVE,
-            content_changed=content_changed,
-            recent_lines=recent_lines,
-            status_override=status_override,
-        )
-
-    def _determine_status(
-        self,
-        content: list[str],
-        last_line: str,
-        idle_seconds: float,
-        old_status: PaneStatus,
-        content_changed: bool,
-    ) -> PaneStatus:
-        """Determine the pane status based on output patterns.
-
-        Once a pane leaves ACTIVE, it keeps its status until content changes.
-        """
-        # If content hasn't changed and we were already in a non-ACTIVE state,
-        # preserve that status until new activity resets us.
-        if not content_changed and old_status != PaneStatus.ACTIVE:
-            return old_status
-
-        # Check for error patterns in recent output
-        recent_lines = content[-10:] if content else []
-        for line in recent_lines:
-            for pattern in self.error_patterns:
-                if pattern.search(line):
-                    return PaneStatus.ERROR
-
-        # Check if the last line looks like a prompt (waiting for input)
-        for pattern in self.prompt_patterns:
-            if pattern.search(last_line):
-                return PaneStatus.WAITING_INPUT
-
-        # Check if the pane has been idle long enough
-        if idle_seconds >= self.idle_threshold:
-            return PaneStatus.IDLE
-
-        return PaneStatus.ACTIVE
-
-    def _detect_structural_changes(
-        self,
-        old_tree: TmuxTree,
-        new_tree: TmuxTree,
-    ) -> list[TmuxEvent]:
-        """Detect additions/removals of sessions, windows, panes, and focus changes."""
-        events: list[TmuxEvent] = []
-
-        old_pane_ids = {p.pane_id for p in old_tree.all_panes()}
-        new_pane_ids = {p.pane_id for p in new_tree.all_panes()}
-
-        for pane_id in new_pane_ids - old_pane_ids:
-            events.append(
-                TmuxEvent(
-                    event_type="pane_added",
-                    pane_id=pane_id,
-                    message=f"Pane added: {pane_id}",
-                )
-            )
-
-        for pane_id in old_pane_ids - new_pane_ids:
-            events.append(
-                TmuxEvent(
-                    event_type="pane_removed",
-                    pane_id=pane_id,
-                    message=f"Pane removed: {pane_id}",
-                )
-            )
-
-        old_session_names = {s.session_name for s in old_tree.sessions}
-        new_session_names = {s.session_name for s in new_tree.sessions}
-
-        for name in new_session_names - old_session_names:
-            events.append(
-                TmuxEvent(
-                    event_type="session_added",
-                    session_name=name,
-                    message=f"Session added: {name}",
-                )
-            )
-
-        for name in old_session_names - new_session_names:
-            events.append(
-                TmuxEvent(
-                    event_type="session_removed",
-                    session_name=name,
-                    message=f"Session removed: {name}",
-                )
-            )
-
-        # Detect active pane (focus) changes
-        old_active = {p.pane_id for p in old_tree.all_panes() if p.is_active}
-        new_active = {p.pane_id for p in new_tree.all_panes() if p.is_active}
-        if old_active != new_active:
-            for pane_id in new_active - old_active:
-                events.append(
-                    TmuxEvent(
-                        event_type="focus_changed",
-                        pane_id=pane_id,
-                        message=f"Focus changed to: {pane_id}",
-                    )
-                )
-
-        return events
 
     def process_notification(self, message: str) -> TmuxEvent | None:
         """Parse a notification message and update pane status if it matches.
@@ -332,7 +222,7 @@ class TmuxWatcher:
         if not self.waiting_trigger_pattern.search(message):
             return None
 
-        activity = self.activities.get(pane_id)
+        activity = self._tracker.activities.get(pane_id)
         if activity is None:
             return None
 

--- a/tests/test_pattern_matcher.py
+++ b/tests/test_pattern_matcher.py
@@ -1,0 +1,109 @@
+"""Tests for muxpilot.pattern_matcher — status determination from pane output."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from muxpilot.pattern_matcher import PatternMatcher
+from muxpilot.models import PaneStatus
+
+
+class TestPatternMatcher:
+    """Tests for PatternMatcher.determine_status."""
+
+    @pytest.fixture
+    def matcher(self):
+        return PatternMatcher(
+            prompt_patterns=[
+                re.compile(r"[\$#>%]\s*$"),
+                re.compile(r"\(y/n\)\s*$", re.IGNORECASE),
+                re.compile(r"\?\s*$"),
+                re.compile(r">>>\s*$"),
+                re.compile(r"\.\.\.\s*$"),
+                re.compile(r"In \[\d+\]:\s*$"),
+                re.compile(r"Press .* to continue", re.IGNORECASE),
+            ],
+            error_patterns=[
+                re.compile(r"(?:Error|ERROR|error)[:.\s]"),
+                re.compile(r"(?:Exception|EXCEPTION)[:.\s]"),
+                re.compile(r"Traceback \(most recent call last\)"),
+                re.compile(r"FAIL(?:ED|URE)?[:.\s]"),
+                re.compile(r"panic[:.\s]"),
+                re.compile(r"FATAL[:.\s]"),
+                re.compile(r"Segmentation fault"),
+            ],
+            idle_threshold=10.0,
+        )
+
+    def test_active_when_content_changing(self, matcher):
+        assert matcher.determine_status(["output"], "output", idle=0.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.ACTIVE
+
+    def test_idle_when_no_change(self, matcher):
+        assert matcher.determine_status(["output"], "output", idle=15.0, old_status=PaneStatus.ACTIVE, content_changed=False) == PaneStatus.IDLE
+
+    def test_idle_threshold_not_met_stays_active(self, matcher):
+        assert matcher.determine_status(["output"], "output", idle=5.0, old_status=PaneStatus.ACTIVE, content_changed=False) == PaneStatus.ACTIVE
+
+    def test_completed_shell_prompt(self, matcher):
+        assert matcher.determine_status(["user@host:~$ "], "user@host:~$ ", idle=0.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.WAITING_INPUT
+
+    def test_waiting_shell_prompt(self, matcher):
+        assert matcher.determine_status(["user@host:~$ "], "user@host:~$ ", idle=15.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.WAITING_INPUT
+
+    def test_waiting_python_repl(self, matcher):
+        assert matcher.determine_status([">>> "], ">>> ", idle=15.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.WAITING_INPUT
+
+    def test_waiting_ipython(self, matcher):
+        assert matcher.determine_status(["In [1]: "], "In [1]: ", idle=15.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.WAITING_INPUT
+
+    def test_waiting_yes_no(self, matcher):
+        assert matcher.determine_status(["Continue? (y/n) "], "Continue? (y/n) ", idle=15.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.WAITING_INPUT
+
+    def test_error_traceback(self, matcher):
+        lines = ["some code", "Traceback (most recent call last)", "  File ..."]
+        assert matcher.determine_status(lines, "  File ...", idle=0.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.ERROR
+
+    def test_error_exception(self, matcher):
+        lines = ["ValueError: invalid literal"]
+        assert matcher.determine_status(lines, lines[-1], idle=0.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.ERROR
+
+    def test_error_failed(self, matcher):
+        lines = ["FAILED: test_xyz"]
+        assert matcher.determine_status(lines, lines[-1], idle=0.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.ERROR
+
+    def test_error_panic(self, matcher):
+        lines = ["panic: runtime error"]
+        assert matcher.determine_status(lines, lines[-1], idle=0.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.ERROR
+
+    def test_error_segfault(self, matcher):
+        lines = ["Segmentation fault"]
+        assert matcher.determine_status(lines, lines[-1], idle=0.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.ERROR
+
+    def test_error_fatal(self, matcher):
+        lines = ["FATAL: cannot start"]
+        assert matcher.determine_status(lines, lines[-1], idle=0.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.ERROR
+
+    def test_error_takes_priority_over_prompt(self, matcher):
+        lines = ["Error: something failed", "user@host:~$ "]
+        assert matcher.determine_status(lines, "user@host:~$ ", idle=15.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.ERROR
+
+    def test_error_persists_when_no_change(self, matcher):
+        assert matcher.determine_status(["Error: old"], "Error: old", idle=60.0, old_status=PaneStatus.ERROR, content_changed=False) == PaneStatus.ERROR
+
+    def test_waiting_persists_when_no_change(self, matcher):
+        assert matcher.determine_status(["$ "], "$ ", idle=60.0, old_status=PaneStatus.WAITING_INPUT, content_changed=False) == PaneStatus.WAITING_INPUT
+
+    def test_error_resets_on_change_without_pattern(self, matcher):
+        assert matcher.determine_status(["normal output"], "normal output", idle=0.0, old_status=PaneStatus.ERROR, content_changed=True) == PaneStatus.ACTIVE
+
+    def test_waiting_resets_on_change_without_pattern(self, matcher):
+        assert matcher.determine_status(["normal output"], "normal output", idle=0.0, old_status=PaneStatus.WAITING_INPUT, content_changed=True) == PaneStatus.ACTIVE
+
+    def test_empty_content(self, matcher):
+        assert matcher.determine_status([], "", idle=0.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.ACTIVE
+
+    def test_only_whitespace_lines(self, matcher):
+        lines = ["   ", "  ", ""]
+        assert matcher.determine_status(lines, "", idle=0.0, old_status=PaneStatus.ACTIVE, content_changed=True) == PaneStatus.ACTIVE

--- a/tests/test_status_tracker.py
+++ b/tests/test_status_tracker.py
@@ -1,0 +1,64 @@
+"""Tests for muxpilot.status_tracker — pane activity lifecycle tracking."""
+
+from __future__ import annotations
+
+import pytest
+
+from muxpilot.status_tracker import StatusTracker
+from muxpilot.models import PaneActivity, PaneStatus
+
+
+class TestStatusTracker:
+    """Tests for StatusTracker.analyze_pane and cleanup."""
+
+    @pytest.fixture
+    def tracker(self):
+        return StatusTracker(preview_lines=30)
+
+    def test_first_analysis(self, tracker):
+        activity = tracker.analyze_pane("%0", ["hello"], None, 0.0)
+        assert activity.pane_id == "%0"
+        assert activity.idle_seconds == 0.0
+        assert activity.last_content_hash != ""
+        assert activity.content_changed is True
+
+    def test_content_unchanged_increments_idle(self, tracker):
+        first = tracker.analyze_pane("%0", ["hello"], None, 0.0)
+        second = tracker.analyze_pane("%0", ["hello"], first, 2.0)
+        assert second.idle_seconds == 2.0
+        assert second.content_changed is False
+
+    def test_content_changed_resets_idle(self, tracker):
+        first = tracker.analyze_pane("%0", ["hello"], None, 0.0)
+        first.idle_seconds = 10.0
+        second = tracker.analyze_pane("%0", ["world"], first, 2.0)
+        assert second.idle_seconds == 0.0
+        assert second.content_changed is True
+
+    def test_recent_lines_truncated(self, tracker):
+        activity = tracker.analyze_pane("%0", ["a", "b", "c", "d"], None, 0.0)
+        assert activity.recent_lines == ["a", "b", "c", "d"]
+
+    def test_empty_content(self, tracker):
+        activity = tracker.analyze_pane("%0", [], None, 0.0)
+        assert activity.last_line == ""
+        assert activity.recent_lines == []
+
+    def test_cleanup_removed(self, tracker):
+        tracker.analyze_pane("%0", ["hello"], None, 0.0)
+        tracker.analyze_pane("%1", ["world"], None, 0.0)
+        tracker.cleanup_removed({"%0"})
+        assert "%0" in tracker.activities
+        assert "%1" not in tracker.activities
+
+    def test_status_override_cleared_on_change(self, tracker):
+        first = tracker.analyze_pane("%0", ["hello"], None, 0.0)
+        first.status_override = PaneStatus.WAITING_INPUT
+        second = tracker.analyze_pane("%0", ["world"], first, 0.0)
+        assert second.status_override is None
+
+    def test_status_override_preserved_when_unchanged(self, tracker):
+        first = tracker.analyze_pane("%0", ["hello"], None, 0.0)
+        first.status_override = PaneStatus.WAITING_INPUT
+        second = tracker.analyze_pane("%0", ["hello"], first, 1.0)
+        assert second.status_override == PaneStatus.WAITING_INPUT

--- a/tests/test_structural_detector.py
+++ b/tests/test_structural_detector.py
@@ -1,0 +1,78 @@
+"""Tests for muxpilot.structural_detector — detecting tree changes."""
+
+from __future__ import annotations
+
+import pytest
+
+from muxpilot.structural_detector import StructuralChangeDetector
+from muxpilot.models import TmuxEvent
+
+from conftest import make_pane, make_session, make_tree, make_window
+
+
+class TestStructuralChangeDetector:
+    """Tests for StructuralChangeDetector.detect."""
+
+    @pytest.fixture
+    def detector(self):
+        return StructuralChangeDetector()
+
+    def test_pane_added(self, detector):
+        old = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])])
+        new = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0"), make_pane(pane_id="%1")])])])
+        events = detector.detect(old, new)
+        assert any(e.event_type == "pane_added" and e.pane_id == "%1" for e in events)
+
+    def test_pane_removed(self, detector):
+        old = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0"), make_pane(pane_id="%1")])])])
+        new = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])])
+        events = detector.detect(old, new)
+        assert any(e.event_type == "pane_removed" and e.pane_id == "%1" for e in events)
+
+    def test_session_added(self, detector):
+        old = make_tree(sessions=[make_session(session_name="s1")])
+        new = make_tree(sessions=[make_session(session_name="s1"), make_session(session_name="s2")])
+        events = detector.detect(old, new)
+        assert any(e.event_type == "session_added" and e.session_name == "s2" for e in events)
+
+    def test_session_removed(self, detector):
+        old = make_tree(sessions=[make_session(session_name="s1"), make_session(session_name="s2")])
+        new = make_tree(sessions=[make_session(session_name="s1")])
+        events = detector.detect(old, new)
+        assert any(e.event_type == "session_removed" and e.session_name == "s2" for e in events)
+
+    def test_no_changes(self, detector):
+        tree = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])])
+        events = detector.detect(tree, tree)
+        assert events == []
+
+    def test_simultaneous_add_remove(self, detector):
+        old = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])])
+        new = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%1")])])])
+        events = detector.detect(old, new)
+        types = {e.event_type for e in events}
+        assert "pane_added" in types
+        assert "pane_removed" in types
+
+    def test_focus_changed(self, detector):
+        old = make_tree(sessions=[make_session(windows=[make_window(panes=[
+            make_pane(pane_id="%0", is_active=True),
+            make_pane(pane_id="%1", is_active=False),
+        ])])])
+        new = make_tree(sessions=[make_session(windows=[make_window(panes=[
+            make_pane(pane_id="%0", is_active=False),
+            make_pane(pane_id="%1", is_active=True),
+        ])])])
+        events = detector.detect(old, new)
+        focus_events = [e for e in events if e.event_type == "focus_changed"]
+        assert len(focus_events) == 1
+        assert focus_events[0].pane_id == "%1"
+
+    def test_no_focus_event_when_unchanged(self, detector):
+        tree = make_tree(sessions=[make_session(windows=[make_window(panes=[
+            make_pane(pane_id="%0", is_active=True),
+            make_pane(pane_id="%1", is_active=False),
+        ])])])
+        events = detector.detect(tree, tree)
+        focus_events = [e for e in events if e.event_type == "focus_changed"]
+        assert focus_events == []

--- a/tests/test_tmux_client.py
+++ b/tests/test_tmux_client.py
@@ -1,4 +1,4 @@
-"""Tests for muxpilot.tmux_client — TmuxClient with mocked libtmux."""
+"""Tests for muxpilot.tmux_client — TmuxClient with mocked libtmux/subprocess."""
 
 from __future__ import annotations
 
@@ -8,56 +8,22 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from muxpilot.tmux_client import (
-    TmuxClient,
-    _is_active_pane,
-    _is_active_str,
-    _is_active_window,
-    _is_attached,
-    _is_attached_str,
-)
+from muxpilot.tmux_client import TmuxClient
 
 
-def _mock_pane(pane_id="%0", cmd="bash", path="/home/user", active="1", w="80", h="24", pid="1234", title=""):
-    p = MagicMock()
-    p.pane_id = pane_id
-    p.pane_index = "0"
-    p.pane_current_command = cmd
-    p.pane_current_path = path
-    p.pane_active = active
-    p.pane_width = w
-    p.pane_height = h
-    p.pane_pid = pid
-    p.pane_title = title
-    return p
+def _list_panes_output(lines: list[str]):
+    class _Result:
+        def __init__(self, stdout: str, stderr: str = "", returncode: int = 0):
+            self.stdout = stdout
+            self.stderr = stderr
+            self.returncode = returncode
 
-
-def _mock_window(wid="@0", name="editor", idx="0", active="1", panes=None):
-    w = MagicMock()
-    w.window_id = wid
-    w.window_name = name
-    w.window_index = idx
-    w.window_active = active
-    w.panes = panes or [_mock_pane()]
-    return w
-
-
-def _mock_session(sname="main", sid="$0", attached="1", windows=None, name=None):
-    s = MagicMock()
-    s.session_name = sname
-    s.session_id = sid
-    s.session_attached = attached
-    s.name = name or sname
-    s.windows = windows or [_mock_window()]
-    return s
-
-
-def _client_with(sessions):
-    c = TmuxClient()
-    mock_server = MagicMock()
-    mock_server.sessions = sessions
-    c._server = mock_server
-    return c
+        def check_returncode(self):
+            if self.returncode != 0:
+                raise subprocess.CalledProcessError(
+                    self.returncode, "tmux", output=self.stdout, stderr=self.stderr
+                )
+    return _Result("\n".join(lines))
 
 
 class TestEnv:
@@ -77,21 +43,6 @@ class TestEnv:
         env = {k: v for k, v in os.environ.items() if k != "TMUX_PANE"}
         with patch.dict(os.environ, env, clear=True):
             assert TmuxClient().get_current_pane_id() is None
-
-
-def _list_panes_output(lines: list[str]):
-    class _Result:
-        def __init__(self, stdout: str, stderr: str = "", returncode: int = 0):
-            self.stdout = stdout
-            self.stderr = stderr
-            self.returncode = returncode
-
-        def check_returncode(self):
-            if self.returncode != 0:
-                raise subprocess.CalledProcessError(
-                    self.returncode, "tmux", output=self.stdout, stderr=self.stderr
-                )
-    return _Result("\n".join(lines))
 
 
 class TestGetTree:
@@ -146,25 +97,42 @@ class TestGetTree:
 
 class TestNavigateTo:
     def test_existing(self):
-        c = _client_with([])
-        assert c.navigate_to("%0") is True
-        c.server.cmd.assert_called_with("switch-client", "-t", "%0")
+        mock_server = MagicMock()
+        with patch("muxpilot.tmux_client.libtmux.Server", return_value=mock_server):
+            c = TmuxClient()
+            assert c.navigate_to("%0") is True
+        mock_server.cmd.assert_called_once_with("switch-client", "-t", "%0")
 
     def test_nonexistent(self):
         import libtmux.exc
-        c = _client_with([])
-        c.server.cmd.side_effect = libtmux.exc.LibTmuxException("not found")
-        assert c.navigate_to("%99") is False
+        mock_server = MagicMock()
+        mock_server.cmd.side_effect = libtmux.exc.LibTmuxException("not found")
+        with patch("muxpilot.tmux_client.libtmux.Server", return_value=mock_server):
+            c = TmuxClient()
+            assert c.navigate_to("%99") is False
+
+
+class TestKillPane:
+    def test_success(self):
+        with patch("muxpilot.tmux_client.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            c = TmuxClient()
+            assert c.kill_pane("%0") is True
+        mock_run.assert_called_once_with(
+            ["tmux", "kill-pane", "-t", "%0"],
+            capture_output=True,
+            check=True,
+            timeout=5.0,
+        )
+
+    def test_failure(self):
+        with patch("muxpilot.tmux_client.subprocess.run", side_effect=subprocess.CalledProcessError(1, "tmux")):
+            c = TmuxClient()
+            assert c.kill_pane("%99") is False
 
 
 class TestCapture:
     def test_returns_list(self):
-        with patch("muxpilot.tmux_client.subprocess.run", return_value=_list_panes_output(["a", "b"])):
-            c = TmuxClient()
-            assert c.capture_pane_content("%0") == ["a", "b"]
-
-    def test_returns_string(self):
-        """tmux capture-pane -p returns stdout as a single string."""
         with patch("muxpilot.tmux_client.subprocess.run", return_value=_list_panes_output(["a", "b"])):
             c = TmuxClient()
             assert c.capture_pane_content("%0") == ["a", "b"]
@@ -191,82 +159,6 @@ class TestCapture:
         )
 
 
-class TestHelpers:
-    def test_attached_true(self):
-        s = MagicMock(); s.session_attached = "1"
-        assert _is_attached(s) is True
-
-    def test_attached_false(self):
-        s = MagicMock(); s.session_attached = "0"
-        assert _is_attached(s) is False
-
-    def test_attached_none(self):
-        s = MagicMock(); s.session_attached = None
-        assert _is_attached(s) is False
-
-    def test_attached_invalid(self):
-        s = MagicMock(); s.session_attached = "abc"
-        assert _is_attached(s) is False
-
-    def test_active_window(self):
-        w = MagicMock(); w.window_active = "1"
-        assert _is_active_window(w) is True
-
-    def test_active_pane(self):
-        p = MagicMock(); p.pane_active = "1"
-        assert _is_active_pane(p) is True
-
-
-class TestGetFullCommand:
-    def test_child_process(self):
-        """When shell has a child process, return child's cmdline."""
-        p = _mock_pane(cmd="bash", pid="1234")
-        c = _client_with([])
-
-        mock_child = MagicMock()
-        mock_child.cmdline.return_value = ["python", "script.py", "--help"]
-        mock_proc = MagicMock()
-        mock_proc.children.return_value = [mock_child]
-        mock_proc.cmdline.return_value = ["bash"]
-
-        with patch("muxpilot.tmux_client.psutil.Process", return_value=mock_proc):
-            result = c._get_full_command(p)
-        assert result == "python script.py --help"
-
-    def test_no_child_process(self):
-        """When no child process, return the shell's own cmdline."""
-        p = _mock_pane(cmd="bash", pid="1234")
-        c = _client_with([])
-
-        mock_proc = MagicMock()
-        mock_proc.children.return_value = []
-        mock_proc.cmdline.return_value = ["bash", "-l"]
-
-        with patch("muxpilot.tmux_client.psutil.Process", return_value=mock_proc):
-            result = c._get_full_command(p)
-        assert result == "bash -l"
-
-    def test_process_not_found(self):
-        """Fallback to pane_current_command when process is gone."""
-        import psutil
-        p = _mock_pane(cmd="bash", pid="1234")
-        c = _client_with([])
-
-        with patch("muxpilot.tmux_client.psutil.Process", side_effect=psutil.NoSuchProcess(1234)):
-            result = c._get_full_command(p)
-        assert result == "bash"
-
-    def test_access_denied(self):
-        """Fallback to pane_current_command on permission error."""
-        import psutil
-        p = _mock_pane(cmd="bash", pid="1234")
-        c = _client_with([])
-
-        with patch("muxpilot.tmux_client.psutil.Process", side_effect=psutil.AccessDenied(1234)):
-            result = c._get_full_command(p)
-        assert result == "bash"
-
-
 class TestPaneTitleAndGit:
     def test_get_tree_reads_pane_title(self):
         line = "s\t$1\t1\t@1\tw\t0\t1\t%1\t0\tbash\t/home/user\t1\t80\t24\t1234\tagent-1"
@@ -288,7 +180,7 @@ class TestPaneTitleAndGit:
         assert pane.branch == "main"
 
     def test_get_git_info_success(self):
-        c = _client_with([])
+        c = TmuxClient()
         with patch("muxpilot.tmux_client.subprocess.run") as mock_run:
             mock_run.side_effect = [
                 MagicMock(stdout="/home/user/proj\n", returncode=0),
@@ -298,21 +190,24 @@ class TestPaneTitleAndGit:
         assert result == {"repo_name": "proj", "branch": "feature/x"}
 
     def test_get_git_info_not_a_repo(self):
-        import subprocess
-        c = _client_with([])
+        c = TmuxClient()
         with patch("muxpilot.tmux_client.subprocess.run", side_effect=subprocess.CalledProcessError(128, "git")):
             result = c._get_git_info("/tmp")
         assert result == {"repo_name": "", "branch": ""}
 
     def test_set_pane_title_calls_tmux(self):
-        c = _client_with([])
-        result = c.set_pane_title("%1", "new-title")
-        c.server.cmd.assert_called_once_with("select-pane", "-t", "%1", "-T", "new-title")
+        mock_server = MagicMock()
+        with patch("muxpilot.tmux_client.libtmux.Server", return_value=mock_server):
+            c = TmuxClient()
+            result = c.set_pane_title("%1", "new-title")
+        mock_server.cmd.assert_called_once_with("select-pane", "-t", "%1", "-T", "new-title")
         assert result is True
 
     def test_set_pane_title_failure(self):
         import libtmux.exc
-        c = _client_with([])
-        c.server.cmd.side_effect = libtmux.exc.LibTmuxException("fail")
-        result = c.set_pane_title("%1", "new-title")
+        mock_server = MagicMock()
+        mock_server.cmd.side_effect = libtmux.exc.LibTmuxException("fail")
+        with patch("muxpilot.tmux_client.libtmux.Server", return_value=mock_server):
+            c = TmuxClient()
+            result = c.set_pane_title("%1", "new-title")
         assert result is False

--- a/tests/test_tree_parser.py
+++ b/tests/test_tree_parser.py
@@ -1,0 +1,91 @@
+"""Tests for muxpilot.tree_parser — TSV parsing of tmux list-panes output."""
+
+from __future__ import annotations
+
+import pytest
+
+from muxpilot.tree_parser import TreeParser
+from muxpilot.models import TmuxTree
+
+
+class TestTreeParser:
+    """Tests for parsing tmux list-panes -F output into TmuxTree."""
+
+    def test_basic_single_pane(self):
+        """Single session/window/pane should parse correctly."""
+        stdout = "dev\t$0\t1\t@0\teditor\t0\t1\t%0\t0\tbash\t/home/user\t1\t80\t24\t1234\tmy-pane"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id=None)
+        assert tree.total_sessions == 1
+        assert tree.total_windows == 1
+        assert tree.total_panes == 1
+        assert tree.sessions[0].session_name == "dev"
+        assert tree.sessions[0].session_id == "$0"
+        assert tree.sessions[0].is_attached is True
+        assert tree.sessions[0].windows[0].window_name == "editor"
+        assert tree.sessions[0].windows[0].panes[0].pane_id == "%0"
+        assert tree.sessions[0].windows[0].panes[0].pane_title == "my-pane"
+
+    def test_multiple_sessions_windows_panes(self):
+        """Multiple sessions, windows, and panes should group correctly."""
+        lines = [
+            "s0\t$0\t1\t@0\tw0\t0\t1\t%0\t0\tbash\t/home/user\t1\t80\t24\t1234\tp0",
+            "s0\t$0\t1\t@0\tw0\t0\t1\t%1\t1\tvim\t/home/user\t0\t80\t24\t1235\tp1",
+            "s0\t$0\t1\t@1\tw1\t1\t0\t%2\t0\tpython\t/home/user\t1\t80\t24\t1236\tp2",
+            "s1\t$1\t0\t@2\tw2\t0\t1\t%3\t0\tzsh\t/home/user\t1\t80\t24\t1237\tp3",
+        ]
+        tree = TreeParser.parse_list_panes_output("\n".join(lines), self_pane_id=None)
+        assert tree.total_sessions == 2
+        assert tree.total_windows == 3
+        assert tree.total_panes == 4
+
+    def test_empty_output(self):
+        """Empty stdout should produce an empty tree."""
+        tree = TreeParser.parse_list_panes_output("", self_pane_id=None)
+        assert tree.total_sessions == 0
+        assert tree.total_windows == 0
+        assert tree.total_panes == 0
+
+    def test_none_values(self):
+        """Tab-only line should not crash and produce zero/empty defaults."""
+        stdout = "\t" * 15
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id=None)
+        assert tree.total_sessions == 1
+        assert tree.total_windows == 1
+        assert tree.total_panes == 1
+        pane = tree.sessions[0].windows[0].panes[0]
+        assert pane.current_command == ""
+        assert pane.current_path == ""
+        assert pane.width == 0
+        assert pane.height == 0
+        assert pane.pane_index == 0
+        assert pane.is_active is False
+
+    def test_self_pane_marking(self):
+        """Pane matching self_pane_id should have is_self=True."""
+        stdout = "dev\t$0\t1\t@0\teditor\t0\t1\t%5\t0\tbash\t/home/user\t1\t80\t24\t1234\t"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id="%5")
+        assert tree.sessions[0].windows[0].panes[0].is_self is True
+
+    def test_non_self_pane(self):
+        """Pane not matching self_pane_id should have is_self=False."""
+        stdout = "dev\t$0\t1\t@0\teditor\t0\t1\t%5\t0\tbash\t/home/user\t1\t80\t24\t1234\t"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id="%99")
+        assert tree.sessions[0].windows[0].panes[0].is_self is False
+
+    def test_skips_short_lines(self):
+        """Lines with fewer than 16 fields should be skipped."""
+        stdout = "dev\t$0\t1\t@0\teditor\t0\t1\t%0\t0\tbash\t/home/user\t1\t80\t24"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id=None)
+        assert tree.total_sessions == 0
+
+    def test_window_active_flag(self):
+        """window_active=0 should produce is_active=False."""
+        stdout = "dev\t$0\t1\t@0\teditor\t0\t0\t%0\t0\tbash\t/home/user\t1\t80\t24\t1234\t"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id=None)
+        assert tree.sessions[0].windows[0].is_active is False
+
+    def test_session_attached_flag(self):
+        """session_attached=0 should produce is_attached=False."""
+        stdout = "dev\t$0\t0\t@0\teditor\t0\t1\t%0\t0\tbash\t/home/user\t1\t80\t24\t1234\t"
+        tree = TreeParser.parse_list_panes_output(stdout, self_pane_id=None)
+        assert tree.sessions[0].is_attached is False

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,4 +1,4 @@
-"""Tests for muxpilot.watcher — pattern detection and structural change detection."""
+"""Integration tests for muxpilot.watcher — TmuxWatcher end-to-end behavior."""
 
 from __future__ import annotations
 
@@ -12,6 +12,7 @@ from muxpilot.watcher import TmuxWatcher
 
 from conftest import make_mock_client, make_pane, make_session, make_tree, make_window
 
+
 def _make_watcher(
     tree=None, capture=None, current_pane_id=None, idle_threshold=10.0, config_path=pathlib.Path("/nonexistent-muxpilot-config")
 ):
@@ -19,170 +20,6 @@ def _make_watcher(
         tree=tree, capture_content=capture, current_pane_id=current_pane_id
     )
     return TmuxWatcher(client, idle_threshold=idle_threshold, config_path=config_path)
-
-
-class TestDetermineStatus:
-    """Tests for _determine_status — the core pattern detection logic."""
-
-    def _status(self, content, last_line="", idle=0.0, threshold=10.0, old_status=None, content_changed=True):
-        w = _make_watcher(idle_threshold=threshold)
-        old_status = old_status if old_status is not None else PaneStatus.ACTIVE
-        return w._determine_status(content, last_line, idle, old_status, content_changed)
-
-    def test_active_when_content_changing(self):
-        assert self._status(["output"], "output", idle=0.0) == PaneStatus.ACTIVE
-
-    def test_idle_when_no_change(self):
-        assert self._status(["output"], "output", idle=15.0, old_status=PaneStatus.ACTIVE, content_changed=False) == PaneStatus.IDLE
-
-    def test_idle_threshold_not_met_stays_active(self):
-        assert self._status(["output"], "output", idle=5.0, old_status=PaneStatus.ACTIVE, content_changed=False) == PaneStatus.ACTIVE
-
-    def test_completed_shell_prompt(self):
-        assert self._status(["user@host:~$ "], "user@host:~$ ", idle=0.0) == PaneStatus.WAITING_INPUT
-
-    def test_waiting_shell_prompt(self):
-        assert self._status(["user@host:~$ "], "user@host:~$ ", idle=15.0) == PaneStatus.WAITING_INPUT
-
-    def test_waiting_python_repl(self):
-        assert self._status([">>> "], ">>> ", idle=15.0) == PaneStatus.WAITING_INPUT
-
-    def test_waiting_ipython(self):
-        assert self._status(["In [1]: "], "In [1]: ", idle=15.0) == PaneStatus.WAITING_INPUT
-
-    def test_waiting_yes_no(self):
-        assert self._status(["Continue? (y/n) "], "Continue? (y/n) ", idle=15.0) == PaneStatus.WAITING_INPUT
-
-    def test_error_traceback(self):
-        lines = ["some code", "Traceback (most recent call last)", "  File ..."]
-        assert self._status(lines, "  File ...", idle=0.0) == PaneStatus.ERROR
-
-    def test_error_exception(self):
-        lines = ["ValueError: invalid literal"]
-        assert self._status(lines, lines[-1], idle=0.0) == PaneStatus.ERROR
-
-    def test_error_failed(self):
-        lines = ["FAILED: test_xyz"]
-        assert self._status(lines, lines[-1], idle=0.0) == PaneStatus.ERROR
-
-    def test_error_panic(self):
-        lines = ["panic: runtime error"]
-        assert self._status(lines, lines[-1], idle=0.0) == PaneStatus.ERROR
-
-    def test_error_segfault(self):
-        lines = ["Segmentation fault"]
-        assert self._status(lines, lines[-1], idle=0.0) == PaneStatus.ERROR
-
-    def test_error_fatal(self):
-        lines = ["FATAL: cannot start"]
-        assert self._status(lines, lines[-1], idle=0.0) == PaneStatus.ERROR
-
-    def test_error_takes_priority_over_prompt(self):
-        """When both error and prompt are present, ERROR should win."""
-        lines = ["Error: something failed", "user@host:~$ "]
-        assert self._status(lines, "user@host:~$ ", idle=15.0) == PaneStatus.ERROR
-
-    def test_error_persists_when_no_change(self):
-        """ERROR status should persist until content changes."""
-        assert self._status(["Error: old"], "Error: old", idle=60.0, old_status=PaneStatus.ERROR, content_changed=False) == PaneStatus.ERROR
-
-    def test_waiting_persists_when_no_change(self):
-        """WAITING_INPUT status should persist until content changes."""
-        assert self._status(["$ "], "$ ", idle=60.0, old_status=PaneStatus.WAITING_INPUT, content_changed=False) == PaneStatus.WAITING_INPUT
-
-    def test_error_resets_on_change_without_pattern(self):
-        """ERROR should reset to ACTIVE when content changes and no error pattern matches."""
-        assert self._status(["normal output"], "normal output", idle=0.0, old_status=PaneStatus.ERROR, content_changed=True) == PaneStatus.ACTIVE
-
-    def test_waiting_resets_on_change_without_pattern(self):
-        """WAITING_INPUT should reset to ACTIVE when content changes and no prompt matches."""
-        assert self._status(["normal output"], "normal output", idle=0.0, old_status=PaneStatus.WAITING_INPUT, content_changed=True) == PaneStatus.ACTIVE
-
-    def test_empty_content(self):
-        assert self._status([], "", idle=0.0) == PaneStatus.ACTIVE
-
-    def test_only_whitespace_lines(self):
-        lines = ["   ", "  ", ""]
-        assert self._status(lines, "", idle=0.0) == PaneStatus.ACTIVE
-
-
-class TestDetectStructuralChanges:
-    """Tests for _detect_structural_changes."""
-
-    def test_pane_added(self):
-        old = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])])
-        new = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0"), make_pane(pane_id="%1")])])])
-        w = _make_watcher()
-        events = w._detect_structural_changes(old, new)
-        assert any(e.event_type == "pane_added" and e.pane_id == "%1" for e in events)
-
-    def test_pane_removed(self):
-        old = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0"), make_pane(pane_id="%1")])])])
-        new = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])])
-        w = _make_watcher()
-        events = w._detect_structural_changes(old, new)
-        assert any(e.event_type == "pane_removed" and e.pane_id == "%1" for e in events)
-
-    def test_session_added(self):
-        old = make_tree(sessions=[make_session(session_name="s1")])
-        new = make_tree(sessions=[make_session(session_name="s1"), make_session(session_name="s2")])
-        w = _make_watcher()
-        events = w._detect_structural_changes(old, new)
-        assert any(e.event_type == "session_added" and e.session_name == "s2" for e in events)
-
-    def test_session_removed(self):
-        old = make_tree(sessions=[make_session(session_name="s1"), make_session(session_name="s2")])
-        new = make_tree(sessions=[make_session(session_name="s1")])
-        w = _make_watcher()
-        events = w._detect_structural_changes(old, new)
-        assert any(e.event_type == "session_removed" and e.session_name == "s2" for e in events)
-
-    def test_no_changes(self):
-        tree = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])])
-        w = _make_watcher()
-        events = w._detect_structural_changes(tree, tree)
-        assert events == []
-
-    def test_simultaneous_add_remove(self):
-        old = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%0")])])])
-        new = make_tree(sessions=[make_session(windows=[make_window(panes=[make_pane(pane_id="%1")])])])
-        w = _make_watcher()
-        events = w._detect_structural_changes(old, new)
-        types = {e.event_type for e in events}
-        assert "pane_added" in types
-        assert "pane_removed" in types
-
-
-class TestAnalyzePane:
-    """Tests for _analyze_pane."""
-
-    def test_first_analysis(self):
-        w = _make_watcher()
-        w._last_tree = make_tree(timestamp=100.0)
-        activity = w._analyze_pane("%0", ["hello"], None, 0.0)
-        assert activity.pane_id == "%0"
-        assert activity.idle_seconds == 0.0
-        assert activity.last_content_hash != ""
-        assert activity.content_changed is True
-
-    def test_content_unchanged_increments_idle(self):
-        w = _make_watcher()
-        w._last_tree = make_tree(timestamp=100.0)
-        first = w._analyze_pane("%0", ["hello"], None, 0.0)
-        w._last_tree = make_tree(timestamp=100.0)
-        second = w._analyze_pane("%0", ["hello"], first, 2.0)
-        assert second.idle_seconds == 2.0
-        assert second.content_changed is False
-
-    def test_content_changed_resets_idle(self):
-        w = _make_watcher()
-        w._last_tree = make_tree(timestamp=100.0)
-        first = w._analyze_pane("%0", ["hello"], None, 0.0)
-        first.idle_seconds = 10.0
-        w._last_tree = make_tree(timestamp=100.0)
-        second = w._analyze_pane("%0", ["world"], first, 2.0)
-        assert second.idle_seconds == 0.0
-        assert second.content_changed is True
 
 
 class TestPoll:


### PR DESCRIPTION
## Summary
- Extract `_determine_status()` logic into standalone `PatternMatcher` class
- Extract `_detect_structural_changes()` into standalone `StructuralChangeDetector` class
- Extract `_analyze_pane()` and activity lifecycle into standalone `StatusTracker` class
- `TmuxWatcher` now composes these three classes and orchestrates `poll()` only
- Move unit tests to dedicated files:
  - `test_pattern_matcher.py` (21 tests)
  - `test_structural_detector.py` (8 tests)
  - `test_status_tracker.py` (8 tests)
- Keep `test_watcher.py` focused on integration tests (`TestPoll`, `TestProcessNotification`)
- Add backward-compatible `prompt_patterns` / `error_patterns` property delegates on `TmuxWatcher`

## Test Plan
- [x] `uv run pytest tests/ -v` — 225 passed, 0 failed
- [x] New `PatternMatcher` tests cover all status transitions (ACTIVE, IDLE, WAITING_INPUT, ERROR)
- [x] New `StructuralChangeDetector` tests cover pane/session add/remove and focus changes
- [x] New `StatusTracker` tests cover content hash, idle time, cleanup, and status_override