### PR TITLE
fix(timer): correct Textual set_interval repeat parameter

### DIFF
--- a/src/muxpilot/timer_coordinator.py
+++ b/src/muxpilot/timer_coordinator.py
@@ -68,7 +68,7 @@ class TimerCoordinator:
     def start(self) -> None:
         """Start the periodic polling timer."""
         self._poll_timer = self._set_interval(
-            self._watcher.poll_interval, self._on_tick_wrapper, repeat=True
+            self._watcher.poll_interval, self._on_tick_wrapper
         )
 
     def stop(self) -> None:
@@ -109,7 +109,7 @@ class TimerCoordinator:
             if self._retry_timer is not None:
                 self._retry_timer.stop()
             self._retry_timer = self._set_interval(
-                self._backoff, self._on_tick_wrapper, repeat=False
+                self._backoff, self._on_tick_wrapper
             )
             return None
 
@@ -117,6 +117,8 @@ class TimerCoordinator:
         self._backoff = self._watcher.poll_interval
         if self._poll_timer is not None:
             self._poll_timer.resume()
+        if self._retry_timer is not None:
+            self._retry_timer.stop()
         return tree, events
 
     async def _on_tick_wrapper(self) -> None:

--- a/tests/test_app_polling.py
+++ b/tests/test_app_polling.py
@@ -123,7 +123,7 @@ async def test_poll_tmux_pauses_timer_on_exception():
         await app._poll_tmux()
         app._polling.poll_timer.pause.assert_called_once()
         mock_set_interval.assert_called_once_with(
-            DEFAULT_POLL_INTERVAL * 2, app._polling._on_tick_wrapper, repeat=False
+            DEFAULT_POLL_INTERVAL * 2, app._polling._on_tick_wrapper
         )
 
 
@@ -163,7 +163,7 @@ async def test_poll_tmux_backoff_caps_at_max():
         await app._poll_tmux()
         assert app._polling.backoff == MAX_POLL_BACKOFF_SECONDS
         mock_set_interval.assert_called_once_with(
-            MAX_POLL_BACKOFF_SECONDS, app._polling._on_tick_wrapper, repeat=False
+            MAX_POLL_BACKOFF_SECONDS, app._polling._on_tick_wrapper
         )
         # Another failure should stay at the cap
         mock_set_interval = MagicMock()
@@ -171,7 +171,7 @@ async def test_poll_tmux_backoff_caps_at_max():
         await app._poll_tmux()
         assert app._polling.backoff == MAX_POLL_BACKOFF_SECONDS
         mock_set_interval.assert_called_once_with(
-            MAX_POLL_BACKOFF_SECONDS, app._polling._on_tick_wrapper, repeat=False
+            MAX_POLL_BACKOFF_SECONDS, app._polling._on_tick_wrapper
         )
 
 

--- a/tests/test_timer_coordinator.py
+++ b/tests/test_timer_coordinator.py
@@ -31,10 +31,9 @@ def _make_coordinator(
         notify = MagicMock()
 
     if set_interval is None:
-        def _set_interval(delay, callback, repeat=True):
+        def _set_interval(delay, callback):
             timer = MagicMock()
             timer.delay = delay
-            timer.repeat = repeat
             return timer
         set_interval = _set_interval
 
@@ -54,7 +53,7 @@ class TestTimerLifecycle:
         tc = _make_coordinator(set_interval=set_interval)
         tc.start()
         set_interval.assert_called_once_with(
-            DEFAULT_POLL_INTERVAL, tc._on_tick_wrapper, repeat=True
+            DEFAULT_POLL_INTERVAL, tc._on_tick_wrapper
         )
 
     def test_stop_stops_timers(self):


### PR DESCRIPTION
## Summary

- Fixed `set_interval()` calls in `TimerCoordinator` that incorrectly passed boolean values for the `repeat` parameter.
  - Textual's `set_interval` expects an **integer**: `0` = repeat forever, `1` = once.
  - `repeat=True` was coerced to `1`, causing the polling timer to stop after 2 ticks → Status stopped updating.
  - `repeat=False` was coerced to `None` (= forever), causing the retry timer to run indefinitely.
- Added missing `retry_timer.stop()` on successful recovery to prevent duplicate polling after error.
- Updated tests to match the corrected `set_interval` call signatures.

## Root Cause

Textual `Timer.__init__` does `repeat=repeat or None` where:
- `True == 1` → stops after 2 ticks
- `False == 0` → `0 or None` → `None` → repeats forever

This meant the polling timer died silently soon after app launch, while the retry timer (meant for one-shot) would keep running forever.

## Test Plan

- [x] `uv run pytest tests/ -v` — 236 tests passing