### PR TITLE
feat: add per-pane CPU/memory resource monitoring

### DIFF
--- a/docs/superpowers/specs/2026-05-16-pane-resource-monitoring-design.md
+++ b/docs/superpowers/specs/2026-05-16-pane-resource-monitoring-design.md
@@ -1,0 +1,80 @@
+# Pane Resource Monitoring Design
+
+## Problem
+
+muxpilot ユーザーが各 tmux pane の CPU / メモリ使用量を知りたい。
+
+## Design
+
+### Data Collection (`resource_collector.py`)
+
+新規モジュール `src/muxpilot/resource_collector.py` を追加。
+
+```python
+@dataclass
+class ResourceInfo:
+    cpu_percent: float
+    memory_rss_kb: int
+
+class ResourceCollector:
+    _cache: dict[int, _ProcessCache]  # PID → prev_cpu_times + prev_time
+
+    def get_resources(self, main_pid: int) -> ResourceInfo | None
+```
+
+- **psutil 拡張**: 既存の `psutil.Process(main_pid)` に対して `cpu_percent()` + `memory_info().rss` を呼ぶ
+- **子プロセス**: `psutil.Process(main_pid).children(recursive=False)` で直近の子プロセスも合算
+  - CPU%: メイン + 各子の `cpu_percent()` を合計
+  - RSS: メイン + 各子の `memory_info().rss` を合算
+- **前回値キャッシュ**: `cpu_percent()` は初回0になるため、`cpu_times() + time.time()` をキャッシュして自力で差分計算
+  - 初回: キャッシュに保存し `None` を返す (次回から計算可能)
+  - 2回目以降: 前回との差分 / elapsed time で CPU% を算出
+- **エラーハンドリング**: `NoSuchProcess`, `AccessDenied`, `ZombieProcess` → `None` を返す
+- **オーバーヘッド**: 最小限。選択中の pane 1つ + その子プロセスのみ
+
+### Data Model (`models.py`)
+
+`PaneInfo` に2フィールド追加:
+
+```python
+cpu_percent: float | None = None
+memory_rss_kb: int | None = None
+```
+
+### Polling Integration (`watcher.py`)
+
+`Watcher.poll()` に変更:
+- 現在フォーカス中の pane (選択中ノード) の `pane_pid` を特定
+- その PID に対してのみ `ResourceCollector.get_resources(pid)` を呼ぶ
+- 結果を当該 `PaneInfo` に書き込む
+
+`TimerCoordinator` の変更は不要（すでに `watcher.poll()` を定期呼び出し中）。
+
+### UI Integration (`app_ui.py` → `detail_panel.py`)
+
+`DetailPanel.show_pane()` にリソース行情報を追加:
+
+```python
+if pane.cpu_percent is not None:
+    mem_mb = pane.memory_rss_kb / 1024 if pane.memory_rss_kb else 0
+    text += f"- **CPU:** {pane.cpu_percent:.1f}%\n"
+    text += f"- **Memory:** {mem_mb:.1f} MB\n"
+```
+
+データがない場合（権限不足・プロセス消失）は行を非表示。
+
+### Key Decisions
+
+| 項目 | 選択 |
+|------|------|
+| プラットフォーム | Linux only |
+| 表示場所 | 詳細パネルのみ |
+| 収集タイミング | 選択中の pane のみポーリングごとに収集（ハイブリッド） |
+| PID取得 | tmux `#{pane_pid}`（既存） |
+| 子プロセス | 直近の子まで合算 |
+| ライブラリ | psutil（既存依存関係） |
+
+### 非機能要件
+
+- プロセス消失後のリソース情報は `None` に戻る（stale 表示を避ける）
+- 子プロセスはポーリングごとに再取得（プロセス生成/終了に追従）

--- a/src/muxpilot/app.py
+++ b/src/muxpilot/app.py
@@ -102,6 +102,7 @@ class MuxpilotApp(App[str | None]):
         self._client = TmuxClient()
         self._watcher = TmuxWatcher(self._client)
         self._current_pane_id: str | None = None
+        self._selected_pane_id: str | None = None
         self._navigate_to: str | None = None
         self._notify_channel = NotifyChannel()
         self._label_store = LabelStore(config_path=config_path)
@@ -175,6 +176,10 @@ class MuxpilotApp(App[str | None]):
         await self._ui.poll_tmux()
 
     def on_tmux_tree_view_node_info(self, message: TmuxTreeView.NodeInfo) -> None:
+        if message.node_type == "pane" and message.pane_info:
+            self._selected_pane_id = str(message.pane_info.pane_id)
+        else:
+            self._selected_pane_id = None
         self._ui.on_tmux_tree_view_node_info(message)
 
     async def on_tmux_tree_view_pane_activated(self, message: TmuxTreeView.PaneActivated) -> None:

--- a/src/muxpilot/app_ui.py
+++ b/src/muxpilot/app_ui.py
@@ -27,7 +27,10 @@ class UIOrchestrator:
     async def do_refresh(self) -> None:
         """Fetch tmux tree and update the UI."""
         try:
-            tree, events = await asyncio.to_thread(self._app._watcher.poll)
+            selected_id = self._app._selected_pane_id
+            tree, events = await asyncio.to_thread(
+                self._app._watcher.poll, selected_id
+            )
         except Exception as e:
             self._app._notify_channel.send(f"Error fetching tmux info: {e}")
             return
@@ -36,6 +39,9 @@ class UIOrchestrator:
 
     async def handle_poll_result(self, tree: TmuxTree, events: list[TmuxEvent]) -> None:
         """Callback passed to TimerCoordinator for each successful poll."""
+        selected_id = self._app._selected_pane_id
+        if selected_id:
+            self._app._watcher.collect_pane_resources(selected_id, tree)
         await self.update_ui_from_poll(tree, events, rebuild_tree=True)
 
     async def poll_tmux(self) -> None:

--- a/src/muxpilot/models.py
+++ b/src/muxpilot/models.py
@@ -59,6 +59,8 @@ class PaneInfo:
     idle_seconds: float = 0.0
     recent_lines: list[str] = field(default_factory=list)
     pane_pid: int = 0
+    cpu_percent: float | None = None
+    memory_rss_kb: int | None = None
 
     def get_display_label(self, icon_override: str | None = None) -> str:
         """Label for tree view display.

--- a/src/muxpilot/resource_collector.py
+++ b/src/muxpilot/resource_collector.py
@@ -38,28 +38,29 @@ class ResourceCollector:
             self._cache.pop(main_pid, None)
             return None
 
-        main_cpu = self._calc_cpu(main_pid, main)
-        main_mem = main.memory_info().rss
+        try:
+            main_cpu = self._calc_cpu(main_pid, main)
+            main_mem = main.memory_info().rss
 
-        child_cpu: float = 0.0
-        child_mem: int = 0
-        for child in main.children(recursive=False):
-            try:
-                child_cpu += self._calc_cpu(child.pid, child) or 0.0
-                child_mem += child.memory_info().rss
-            except (psutil.NoSuchProcess, psutil.AccessDenied):
-                pass
+            child_cpu: float = 0.0
+            child_mem: int = 0
+            for child in main.children(recursive=False):
+                try:
+                    child_cpu += self._calc_cpu(child.pid, child) or 0.0
+                    child_mem += child.memory_info().rss
+                except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+                    pass
 
-        if main_cpu is None:
+            if main_cpu is None:
+                return None
+
+            return ResourceInfo(
+                cpu_percent=min(main_cpu + child_cpu, 100.0),
+                memory_rss_kb=(main_mem + child_mem) // 1024,
+            )
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            self._cache.pop(main_pid, None)
             return None
-
-        cpu = main_cpu + child_cpu
-        mem = main_mem + child_mem
-
-        return ResourceInfo(
-            cpu_percent=min(cpu, 100.0),
-            memory_rss_kb=mem // 1024,
-        )
 
     def _calc_cpu(self, pid: int, proc: psutil.Process) -> float | None:
         """Calculate CPU% since the last call. Returns None on first call."""

--- a/src/muxpilot/resource_collector.py
+++ b/src/muxpilot/resource_collector.py
@@ -43,12 +43,12 @@ class ResourceCollector:
 
         child_cpu: float = 0.0
         child_mem: int = 0
-        try:
-            for child in main.children(recursive=False):
+        for child in main.children(recursive=False):
+            try:
                 child_cpu += self._calc_cpu(child.pid, child) or 0.0
                 child_mem += child.memory_info().rss
-        except (psutil.NoSuchProcess, psutil.AccessDenied):
-            pass
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
 
         if main_cpu is None:
             return None

--- a/src/muxpilot/resource_collector.py
+++ b/src/muxpilot/resource_collector.py
@@ -1,0 +1,86 @@
+"""CPU and memory resource collection for tmux panes."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+import psutil
+
+
+@dataclass
+class ResourceInfo:
+    cpu_percent: float
+    memory_rss_kb: int
+
+
+@dataclass
+class _ProcessCache:
+    cpu_times: object
+    time: float
+
+
+class ResourceCollector:
+    """Collects CPU and memory usage for a process and its direct children."""
+
+    def __init__(self) -> None:
+        self._cache: dict[int, _ProcessCache] = {}
+
+    def get_resources(self, main_pid: int) -> ResourceInfo | None:
+        """Get CPU% and memory RSS for the given PID and its direct children.
+
+        Returns None on first call (needs a baseline), or when the process
+        does not exist or is inaccessible.
+        """
+        try:
+            main = psutil.Process(main_pid)
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            self._cache.pop(main_pid, None)
+            return None
+
+        main_cpu = self._calc_cpu(main_pid, main)
+        main_mem = main.memory_info().rss
+
+        child_cpu: float = 0.0
+        child_mem: int = 0
+        try:
+            for child in main.children(recursive=False):
+                child_cpu += self._calc_cpu(child.pid, child) or 0.0
+                child_mem += child.memory_info().rss
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+
+        if main_cpu is None:
+            return None
+
+        cpu = main_cpu + child_cpu
+        mem = main_mem + child_mem
+
+        return ResourceInfo(
+            cpu_percent=min(cpu, 100.0),
+            memory_rss_kb=mem // 1024,
+        )
+
+    def _calc_cpu(self, pid: int, proc: psutil.Process) -> float | None:
+        """Calculate CPU% since the last call. Returns None on first call."""
+        now = time.monotonic()
+        try:
+            times = proc.cpu_times()
+        except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess):
+            self._cache.pop(pid, None)
+            return None
+
+        prev = self._cache.get(pid)
+        if prev is None:
+            self._cache[pid] = _ProcessCache(cpu_times=times, time=now)
+            return None
+
+        delta_cpu = (times.user + times.system) - (prev.cpu_times.user + prev.cpu_times.system)
+        delta_time = now - prev.time
+
+        self._cache[pid] = _ProcessCache(cpu_times=times, time=now)
+
+        if delta_time <= 0:
+            return 0.0
+
+        return (delta_cpu / delta_time) * 100.0

--- a/src/muxpilot/watcher.py
+++ b/src/muxpilot/watcher.py
@@ -16,6 +16,7 @@ from muxpilot.models import (
     TmuxTree,
 )
 from muxpilot.pattern_matcher import PatternMatcher
+from muxpilot.resource_collector import ResourceCollector
 from muxpilot.status_tracker import StatusTracker
 from muxpilot.structural_detector import StructuralChangeDetector
 from muxpilot.tmux_client import TmuxClient
@@ -118,6 +119,7 @@ class TmuxWatcher:
         )
         self._tracker = StatusTracker(preview_lines=preview_lines)
         self._detector = StructuralChangeDetector()
+        self._resource_collector = ResourceCollector()
 
         self._last_tree: TmuxTree | None = None
         self._last_poll_time: float | None = None
@@ -147,7 +149,7 @@ class TmuxWatcher:
         """Replace the activity tracker state (for tests)."""
         self._tracker.activities = value
 
-    def poll(self) -> tuple[TmuxTree, list[TmuxEvent]]:
+    def poll(self, collect_pane_id: str | None = None) -> tuple[TmuxTree, list[TmuxEvent]]:
         """
         Perform one poll cycle:
         1. Fetch the current tmux tree
@@ -223,6 +225,9 @@ class TmuxWatcher:
         current_pane_ids = {p.pane_id for p in new_tree.all_panes()}
         self._tracker.cleanup_removed(current_pane_ids)
 
+        if collect_pane_id:
+            self.collect_pane_resources(collect_pane_id, new_tree)
+
         self._last_tree = new_tree
         self._last_poll_time = now
         logger.debug("poll end events=%d", len(events))
@@ -274,3 +279,16 @@ class TmuxWatcher:
             new_status=PaneStatus.WAITING_INPUT,
             message=f"{pane_id}: {old_status.value} → {PaneStatus.WAITING_INPUT.value}",
         )
+
+    def collect_pane_resources(self, pane_id: str, tree: TmuxTree) -> None:
+        """Collect CPU/memory for the specified pane and store results on its PaneInfo."""
+        for pane in tree.all_panes():
+            if pane.pane_id == pane_id and pane.pane_pid:
+                info = self._resource_collector.get_resources(pane.pane_pid)
+                if info is not None:
+                    pane.cpu_percent = info.cpu_percent
+                    pane.memory_rss_kb = info.memory_rss_kb
+                else:
+                    pane.cpu_percent = None
+                    pane.memory_rss_kb = None
+                break

--- a/src/muxpilot/widgets/detail_panel.py
+++ b/src/muxpilot/widgets/detail_panel.py
@@ -94,6 +94,11 @@ class DetailPanel(Widget):
             f"- **Status:** {status_name.upper()}{idle_text}\n"
         )
 
+        if pane.cpu_percent is not None:
+            mem_mb = pane.memory_rss_kb / 1024 if pane.memory_rss_kb else 0
+            text += f"- **CPU:** {pane.cpu_percent:.1f}%\n"
+            text += f"- **Memory:** {mem_mb:.1f} MB\n"
+
         if pane.status == PaneStatus.ERROR:
             text += "\n> **Status is ERROR**\n"
         elif pane.status == PaneStatus.WAITING_INPUT:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,8 @@ def make_pane(
     idle_seconds: float = 0.0,
     recent_lines: list[str] | None = None,
     pane_pid: int = 0,
+    cpu_percent: float | None = None,
+    memory_rss_kb: int | None = None,
 ) -> PaneInfo:
     """Create a PaneInfo with sensible defaults."""
     return PaneInfo(
@@ -52,6 +54,8 @@ def make_pane(
         idle_seconds=idle_seconds,
         recent_lines=recent_lines or [],
         pane_pid=pane_pid,
+        cpu_percent=cpu_percent,
+        memory_rss_kb=memory_rss_kb,
     )
 
 

--- a/tests/test_app_detail_panel.py
+++ b/tests/test_app_detail_panel.py
@@ -231,6 +231,32 @@ async def test_detail_panel_session_does_not_show_counts():
     assert "**Panes:**" not in text
 
 
+@pytest.mark.asyncio
+async def test_detail_panel_shows_resources():
+    """Detail panel should display CPU and memory when available."""
+    panel = DetailPanel()
+    session = make_session(session_name="dev", windows=[
+        make_window(window_name="editor", panes=[
+            make_pane(
+                pane_id="%3",
+                pane_pid=9999,
+                cpu_percent=45.2,
+                memory_rss_kb=512_000,
+            )
+        ])
+    ])
+    window = session.windows[0]
+    pane = window.panes[0]
+    app = _run_detail_panel(panel)
+    async with app.run_test():
+        panel.show_pane(pane, window, session)
+        text = panel._markdown_source
+        assert "CPU:" in text
+        assert "45.2%" in text
+        assert "Memory:" in text
+        assert "500.0 MB" in text  # 512000/1024 = 500.0
+
+
 # ============================================================================
 # Polling: error handling and backoff
 # ============================================================================

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -294,3 +294,18 @@ class TestShortenPath:
         """Home directory itself should become '~'."""
         home = os.path.expanduser("~")
         assert _shorten_path(home) == "~"
+
+
+# ============================================================================
+# PaneInfo resource fields
+# ============================================================================
+
+
+def test_pane_info_resource_fields():
+    pane = make_pane(pane_pid=1234)
+    assert pane.cpu_percent is None
+    assert pane.memory_rss_kb is None
+    pane.cpu_percent = 12.5
+    pane.memory_rss_kb = 256_000
+    assert pane.cpu_percent == 12.5
+    assert pane.memory_rss_kb == 256_000

--- a/tests/test_resource_collector.py
+++ b/tests/test_resource_collector.py
@@ -63,7 +63,7 @@ def test_get_resources_includes_children():
         assert second is not None
         # RSS: 64MB + 32MB = 96MB -> 93750 KB
         assert second.memory_rss_kb == 93750
-        assert 0 <= second.cpu_percent <= 100.0
+        assert second.cpu_percent == pytest.approx(18.0)
 
 
 def test_get_resources_returns_none_on_error():

--- a/tests/test_resource_collector.py
+++ b/tests/test_resource_collector.py
@@ -1,0 +1,85 @@
+"""Tests for ResourceCollector."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import psutil
+import pytest
+
+from muxpilot.resource_collector import ResourceCollector, ResourceInfo
+
+
+def test_get_resources_returns_resource_info():
+    collector = ResourceCollector()
+    mock_proc = MagicMock(spec=psutil.Process)
+    mock_proc.pid = 9999
+    mock_proc.cpu_times.return_value = MagicMock(user=100.0, system=50.0)
+    mock_proc.memory_info.return_value = MagicMock(rss=128_000_000)  # 128 MB
+    mock_proc.children.return_value = []
+
+    with (
+        patch("muxpilot.resource_collector.psutil.Process", return_value=mock_proc),
+        patch("muxpilot.resource_collector.time.monotonic", side_effect=[1.0, 2.0]),
+    ):
+        # First call: caches, returns None (need two samples)
+        result1 = collector.get_resources(9999)
+        assert result1 is None
+
+        # Second call: cpu usage went from (100+50=150) to (101+51=152)
+        # delta = 2 sec CPU, elapsed = 1 sec -> 200% -> capped at 100%
+        mock_proc.cpu_times.return_value = MagicMock(user=101.0, system=51.0)
+        result2 = collector.get_resources(9999)
+        assert result2 is not None
+        assert result2.cpu_percent == 100.0  # capped
+        assert result2.memory_rss_kb == 125000  # 128_000_000 / 1024
+
+
+def test_get_resources_includes_children():
+    collector = ResourceCollector()
+    main_mock = MagicMock(spec=psutil.Process)
+    main_mock.pid = 100
+    main_mock.cpu_times.return_value = MagicMock(user=10.0, system=5.0)
+    main_mock.memory_info.return_value = MagicMock(rss=64_000_000)
+
+    child = MagicMock(spec=psutil.Process)
+    child.pid = 101
+    child.cpu_times.return_value = MagicMock(user=2.0, system=1.0)
+    child.memory_info.return_value = MagicMock(rss=32_000_000)
+
+    main_mock.children.return_value = [child]
+
+    with (
+        patch("muxpilot.resource_collector.psutil.Process", return_value=main_mock),
+        patch("muxpilot.resource_collector.time.monotonic", side_effect=[0.0, 0.1, 1.0, 1.1]),
+    ):
+        first = collector.get_resources(100)
+        assert first is None
+
+        main_mock.cpu_times.return_value = MagicMock(user=10.1, system=5.05)
+        child.cpu_times.return_value = MagicMock(user=2.02, system=1.01)
+
+        second = collector.get_resources(100)
+        assert second is not None
+        # RSS: 64MB + 32MB = 96MB -> 93750 KB
+        assert second.memory_rss_kb == 93750
+        assert 0 <= second.cpu_percent <= 100.0
+
+
+def test_get_resources_returns_none_on_error():
+    collector = ResourceCollector()
+    with patch("muxpilot.resource_collector.psutil.Process", side_effect=psutil.NoSuchProcess(9999)):
+        result = collector.get_resources(9999)
+        assert result is None
+
+
+def test_get_resources_handles_access_denied():
+    collector = ResourceCollector()
+    with patch("muxpilot.resource_collector.psutil.Process", side_effect=psutil.AccessDenied()):
+        result = collector.get_resources(9999)
+        assert result is None
+
+
+def test_get_resources_empty_cache_on_first_call():
+    collector = ResourceCollector()
+    assert collector._cache == {}

--- a/tests/test_resource_collector.py
+++ b/tests/test_resource_collector.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import psutil
 import pytest
 
-from muxpilot.resource_collector import ResourceCollector, ResourceInfo
+from muxpilot.resource_collector import ResourceCollector
 
 
 def test_get_resources_returns_resource_info():

--- a/tests/test_resource_collector.py
+++ b/tests/test_resource_collector.py
@@ -83,3 +83,22 @@ def test_get_resources_handles_access_denied():
 def test_get_resources_empty_cache_on_first_call():
     collector = ResourceCollector()
     assert collector._cache == {}
+
+
+def test_get_resources_handles_zombie():
+    collector = ResourceCollector()
+    with patch("muxpilot.resource_collector.psutil.Process", side_effect=psutil.ZombieProcess(9999)):
+        result = collector.get_resources(9999)
+        assert result is None
+
+
+def test_get_resources_handles_process_dies_mid_call():
+    collector = ResourceCollector()
+    mock_proc = MagicMock(spec=psutil.Process)
+    mock_proc.pid = 9999
+    mock_proc.cpu_times.return_value = MagicMock(user=1.0, system=0.5)
+    mock_proc.memory_info.side_effect = psutil.NoSuchProcess(9999)
+
+    with patch("muxpilot.resource_collector.psutil.Process", return_value=mock_proc):
+        result = collector.get_resources(9999)
+        assert result is None

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -265,3 +265,39 @@ class TestProcessNotification:
         assert "process_notification" in caplog.text
         assert "%0" in caplog.text
         assert "override set" in caplog.text
+
+
+class TestResourceCollection:
+    """Tests for resource collection integration in poll()."""
+
+    def test_poll_collects_resources_for_selected_pane(self):
+        from unittest.mock import MagicMock
+
+        from conftest import make_mock_client, make_pane, make_session, make_tree, make_window
+
+        tree = make_tree(sessions=[make_session(windows=[make_window(panes=[
+            make_pane(pane_id="%1", pane_pid=100),
+            make_pane(pane_id="%2", pane_pid=200),
+        ])])])
+        client = make_mock_client(tree=tree)
+        watcher = TmuxWatcher(client, capture_lines=5)
+
+        # Mock ResourceCollector
+        mock_collector = MagicMock()
+        mock_collector.get_resources.return_value = MagicMock(
+            cpu_percent=23.5, memory_rss_kb=256_000
+        )
+        watcher._resource_collector = mock_collector
+
+        tree, events = watcher.poll(collect_pane_id="%1")
+
+        # Check that the resource was collected for the right pane
+        for pane in tree.all_panes():
+            if pane.pane_id == "%1":
+                assert pane.cpu_percent == 23.5
+                assert pane.memory_rss_kb == 256_000
+            else:
+                assert pane.cpu_percent is None
+                assert pane.memory_rss_kb is None
+
+        mock_collector.get_resources.assert_called_once_with(100)


### PR DESCRIPTION
## Summary

- **New `ResourceCollector` class** (`src/muxpilot/resource_collector.py`) — uses psutil to collect CPU% and memory RSS for a process and its direct children
- **Hybrid collection** — resources are collected only for the pane currently selected in the tree view, minimizing overhead
- **Detail panel display** — CPU% and memory shown in the detail panel when a pane is selected
- **Two-call CPU% calculation** — first call establishes baseline, subsequent calls compute CPU% from `cpu_times()` deltas

## Architecture

```
tmux #{pane_pid} → ResourceCollector.get_resources(pid)
  → psutil.Process(main_pid)
  → cpu_times() deltas (cached) for CPU%
  → memory_info().rss for memory (summed with direct children)
  → PaneInfo.cpu_percent / .memory_rss_kb
  → DetailPanel.show_pane() display
```

## Test Plan

- [x] `tests/test_resource_collector.py` — 7 tests (basic, children, errors, race conditions)
- [x] `tests/test_watcher.py` — resource collection integration test
- [x] `tests/test_app_detail_panel.py` — resource display test
- [x] 298 tests pass, 0 failures
- [x] ruff lint clean (new code only)